### PR TITLE
Add online training bundle packager

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ uv sync --locked
 # 训练 starter baseline
 uv run taac-train --experiment config/baseline
 
+# 打包单个实验包为线上训练 zip
+uv run taac-package-train --experiment config/baseline
+
 # 用 optuna 搜索 baseline，默认会按当前可见 GPU 空闲显存自动并行派发 trial
 # 默认约束仍然是参数量 <= 3 GiB、验证集端到端推理总时长 <= 180 秒
 uv run taac-search --experiment config/baseline --trials 20
@@ -102,7 +105,7 @@ uv run pytest tests -q
 | UniScaleFormer | [config/uniscaleformer](config/uniscaleformer)         | [twx145/Unirec](https://github.com/twx145/Unirec)                                                                                             | `outputs/config/uniscaleformer` | forward regression + smoke summary |
 | O_o            | [config/oo](config/oo)                                 | [salmon1802/O_o](https://github.com/salmon1802/O_o)                                                                                           | `outputs/config/oo`          | forward regression + smoke summary |
 
-更详细的训练命令、输出文件说明和各实验包说明，可以看 [docs/getting-started.md](docs/getting-started.md)、[docs/experiments/index.md](docs/experiments/index.md) 和 [docs/architecture.md](docs/architecture.md)。
+更详细的训练命令、线上训练打包说明和各实验包说明，可以看 [docs/getting-started.md](docs/getting-started.md)、[docs/guide/online-training-bundle.md](docs/guide/online-training-bundle.md)、[docs/experiments/index.md](docs/experiments/index.md) 和 [docs/architecture.md](docs/architecture.md)。
 
 ------
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -78,6 +78,14 @@ outputs/config/baseline/
 uv run taac-train --experiment config/baseline --compile --amp --amp-dtype bfloat16
 ```
 
+如果你需要把单个实验包上传到线上训练平台，可以先生成单 zip：
+
+```bash
+uv run taac-package-train --experiment config/baseline
+```
+
+默认产物会写到 `outputs/training_bundles/baseline-train-bundle.zip`。
+
 ## 评估
 
 ```bash
@@ -131,6 +139,46 @@ uv run taac-train --experiment config/hyformer
 
 → 完整实验包列表见 [实验包总览](experiments/index.md)
 
+## 线上训练打包
+
+`taac-package-train` 会把指定实验包裁剪成训练所需的最小运行时，并输出单个 zip。
+zip 顶层包含：
+
+- `run.sh`：自动解压 payload、执行 `uv sync`、调用训练 CLI
+- `runtime_payload.tar.gz`：最小训练源码与目标实验包
+- `bundle_manifest.json`：打包元数据
+- `README.md`：压缩包内的使用说明
+
+```bash
+# 生成默认命名的 zip
+uv run taac-package-train --experiment config/baseline
+
+# 自定义输出文件名
+uv run taac-package-train --experiment config/interformer --output /tmp/interformer-online.zip --force
+```
+
+解压后，线上环境最少只需要：
+
+```bash
+export TAAC_DATASET_PATH=/path/to/train.parquet
+bash run.sh --compile --amp --amp-dtype bfloat16
+```
+
+其中：
+
+- `TAAC_DATASET_PATH` 必填，指向 parquet 文件或数据缓存目录
+- `TAAC_OUTPUT_DIR` 可选，覆盖训练输出目录
+- `TAAC_ENABLE_TE=1` 可选，为 bundle 安装 transformer-engine 额外依赖
+- `TAAC_FORCE_EXTRACT=1` 可选，强制重新解压 payload
+
+如果你不走 bundle，也可以直接对训练 CLI 传运行时数据路径：
+
+```bash
+uv run taac-train --experiment config/baseline --dataset-path /path/to/train.parquet
+```
+
+→ 完整参数和目录结构见 [线上训练打包](guide/online-training-bundle.md)
+
 ## 跑测试
 
 ```bash
@@ -167,6 +215,7 @@ uv run --no-project --isolated --with zensical zensical build --clean
 | `taac-train`                  | 训练实验包         |
 | `taac-evaluate`               | 评估 checkpoint    |
 | `taac-search`                 | Optuna 超参数搜索  |
+| `taac-package-train`          | 打包线上训练 zip   |
 | `taac-bench-report`           | 生成 benchmark 图表 |
 | `taac-plot-model-performance` | 生成性能对比图     |
 | `taac-clean-pycache`          | 清理 `__pycache__` |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -144,10 +144,12 @@ uv run taac-train --experiment config/hyformer
 `taac-package-train` 会把指定实验包裁剪成训练所需的最小运行时，并输出单个 zip。
 zip 顶层包含：
 
-- `run.sh`：自动解压 payload、执行 `uv sync`、调用训练 CLI
+- `run.sh`：自动解压 payload、执行 `uv sync --locked`、调用训练 CLI
 - `runtime_payload.tar.gz`：最小训练源码与目标实验包
 - `bundle_manifest.json`：打包元数据
 - `README.md`：压缩包内的使用说明
+
+其中 `runtime_payload.tar.gz` 解压后包含 `pyproject.toml`、`uv.lock` 和最小训练源码。
 
 ```bash
 # 生成默认命名的 zip

--- a/docs/guide/online-training-bundle.md
+++ b/docs/guide/online-training-bundle.md
@@ -1,0 +1,181 @@
+---
+icon: lucide/package
+---
+
+# 线上训练打包
+
+当线上平台要求你手动上传代码和启动脚本时，推荐先用 `taac-package-train` 生成单个 zip。
+这个命令会把指定实验包和训练所需的最小运行时裁剪出来，避免把 tests、文档、搜索 CLI、其他实验包一并上传。
+
+## 适用场景
+
+- 线上训练环境只接受单个压缩包上传
+- 你希望每次只发布一个实验包，而不是整个仓库
+- 平台提供统一的数据挂载路径和 bash 入口
+
+## 生成 zip
+
+```bash
+# 使用默认命名
+uv run taac-package-train --experiment config/baseline
+
+# 自定义 zip 文件名
+uv run taac-package-train --experiment config/interformer --bundle-name interformer-round1
+
+# 覆盖已有产物
+uv run taac-package-train --experiment config/interformer --output /tmp/interformer-online.zip --force
+```
+
+默认输出目录：
+
+```text
+outputs/training_bundles/
+```
+
+例如 baseline 会生成：
+
+```text
+outputs/training_bundles/baseline-train-bundle.zip
+```
+
+## 压缩包结构
+
+生成的 zip 顶层包含：
+
+```text
+baseline-train-bundle.zip
+├── README.md
+├── bundle_manifest.json
+├── run.sh
+└── runtime_payload.tar.gz
+```
+
+其中：
+
+- `run.sh` 负责解压 payload、安装依赖并执行训练
+- `runtime_payload.tar.gz` 里包含最小训练源码和目标实验包
+- `bundle_manifest.json` 记录实验路径、环境变量名和 payload 统计信息
+
+payload 内部大致结构如下：
+
+```text
+project/
+├── config/
+│   └── baseline/
+├── pyproject.toml
+└── src/
+    └── taac2026/
+        ├── __init__.py
+        ├── application/
+        │   ├── __init__.py
+        │   └── training/
+        ├── domain/
+        └── infrastructure/
+```
+
+这里不会包含：
+
+- `tests/`
+- `docs/`
+- `site/`
+- 其他 `config/<name>/`
+- 搜索和评估 CLI
+
+## 线上运行方式
+
+解压 zip 后，至少设置数据路径再执行 `run.sh`：
+
+```bash
+export TAAC_DATASET_PATH=/path/to/train.parquet
+bash run.sh
+```
+
+如果你要显式打开运行时优化开关：
+
+```bash
+export TAAC_DATASET_PATH=/path/to/train.parquet
+export TAAC_OUTPUT_DIR=/path/to/output
+bash run.sh --compile --amp --amp-dtype bfloat16
+```
+
+`run.sh` 内部执行的是：
+
+```bash
+uv sync
+uv run taac-train --experiment ./config/baseline --dataset-path "$TAAC_DATASET_PATH" --run-dir "$TAAC_OUTPUT_DIR"
+```
+
+也就是说，bundle 本质上仍然复用了仓库里的训练 CLI，只是把输入裁成了最小可上传运行时。
+
+## 环境变量
+
+| 变量 | 是否必填 | 作用 |
+| ---- | -------- | ---- |
+| `TAAC_DATASET_PATH` | 是 | 线上数据路径，支持 parquet 文件或数据缓存目录 |
+| `TAAC_OUTPUT_DIR` | 否 | 覆盖训练产物输出目录，默认写到 zip 同级 `outputs/` |
+| `TAAC_BUNDLE_WORKDIR` | 否 | 控制 payload 的解压目录 |
+| `TAAC_ENABLE_TE` | 否 | 设为 `1` 时安装 `transformer-engine` 额外依赖 |
+| `TAAC_FORCE_EXTRACT` | 否 | 设为 `1` 时强制重新解压 `runtime_payload.tar.gz` |
+
+## 与直接训练的区别
+
+直接在仓库里训练时，实验包通常使用仓库内默认的数据缓存路径：
+
+```bash
+uv run taac-train --experiment config/baseline
+```
+
+而 bundle 需要显式告诉运行时数据在哪，所以训练 CLI 新增了 `--dataset-path` 覆盖项：
+
+```bash
+uv run taac-train --experiment config/baseline --dataset-path /path/to/train.parquet
+```
+
+这使得：
+
+- 本地仓库训练仍可继续用默认数据路径
+- 线上训练 bundle 可以在外部挂载数据目录上直接运行
+
+## 常见问题
+
+### `TAAC_DATASET_PATH` 未设置
+
+`run.sh` 会直接退出并返回非零状态。先设置环境变量再运行：
+
+```bash
+export TAAC_DATASET_PATH=/path/to/train.parquet
+bash run.sh
+```
+
+### 已有旧 payload，但想重新展开
+
+```bash
+export TAAC_DATASET_PATH=/path/to/train.parquet
+export TAAC_FORCE_EXTRACT=1
+bash run.sh
+```
+
+### 线上环境需要额外的 Transformer Engine
+
+```bash
+export TAAC_DATASET_PATH=/path/to/train.parquet
+export TAAC_ENABLE_TE=1
+bash run.sh
+```
+
+### 想检查 bundle 实际包含了什么
+
+可以直接查看 `bundle_manifest.json`，或者本地解压 `runtime_payload.tar.gz` 验证结构。
+
+## 相关命令
+
+```bash
+# 本地训练
+uv run taac-train --experiment config/baseline
+
+# 线上训练打包
+uv run taac-package-train --experiment config/baseline
+
+# 直接覆盖数据路径
+uv run taac-train --experiment config/baseline --dataset-path /path/to/train.parquet
+```

--- a/docs/guide/online-training-bundle.md
+++ b/docs/guide/online-training-bundle.md
@@ -56,6 +56,8 @@ baseline-train-bundle.zip
 - `runtime_payload.tar.gz` 里包含最小训练源码和目标实验包
 - `bundle_manifest.json` 记录实验路径、环境变量名和 payload 统计信息
 
+其中 `runtime_payload.tar.gz` 解压后还会包含 `pyproject.toml` 与 `uv.lock`，用于保持与仓库一致的锁定依赖解析。
+
 payload 内部大致结构如下：
 
 ```text
@@ -63,6 +65,7 @@ project/
 ├── config/
 │   └── baseline/
 ├── pyproject.toml
+├── uv.lock
 └── src/
     └── taac2026/
         ├── __init__.py
@@ -101,7 +104,7 @@ bash run.sh --compile --amp --amp-dtype bfloat16
 `run.sh` 内部执行的是：
 
 ```bash
-uv sync
+uv sync --locked
 uv run taac-train --experiment ./config/baseline --dataset-path "$TAAC_DATASET_PATH" --run-dir "$TAAC_OUTPUT_DIR"
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ icon: lucide/house
 | ---------------- | ------------------------------------------------------------- |
 | **统一训练框架** | 一条命令完成训练、评估、checkpoint 保存                       |
 | **目录式实验包** | 每个实验包独立管理数据、模型、损失函数，互不干扰              |
+| **线上训练打包** | 将指定实验包压缩成单个 zip，并提供自动解压和训练入口脚本      |
 | **超参数搜索**   | 基于 Optuna，自动检测 GPU 空闲显存并发派发 trial              |
 | **回归测试**     | Unit / Integration / Property 三层测试，CI 自动覆盖率门控     |
 | **论文复现**     | 内置 InterFormer、OneTrans、HyFormer 等已发表工作的可运行实现 |
@@ -60,6 +61,9 @@ uv sync --locked
 # 训练 baseline
 uv run taac-train --experiment config/baseline
 
+# 打包 baseline 为线上训练 zip
+uv run taac-package-train --experiment config/baseline
+
 # 评估
 uv run taac-evaluate single --experiment config/baseline
 
@@ -68,3 +72,5 @@ uv run taac-search --experiment config/baseline --trials 20
 ```
 
 → 详细步骤见 [快速开始](getting-started.md)
+
+→ 线上训练压缩包格式见 [线上训练打包](guide/online-training-bundle.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ explicit = true
 taac-train = "taac2026.application.training.cli:main"
 taac-evaluate = "taac2026.application.evaluation.cli:main"
 taac-search = "taac2026.application.search.cli:main"
+taac-package-train = "taac2026.application.maintenance.package_training:main"
 taac-clean-pycache = "taac2026.application.maintenance.clean_pycache:main"
 taac-clean-github-logs = "taac2026.application.maintenance.github_cleanup:main"
 taac-plot-model-performance = "taac2026.application.reporting.cli:main"
@@ -64,6 +65,9 @@ package-dir = { "" = "src" }
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.package-data]
+"taac2026.application.maintenance.templates" = ["*.tmpl"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/taac2026/application/maintenance/package_training.py
+++ b/src/taac2026/application/maintenance/package_training.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+import argparse
+from importlib.resources import files
+import json
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import shutil
+import sys
+import tarfile
+import tempfile
+import zipfile
+
+from ...infrastructure.io.console import print_summary_table
+from ...infrastructure.io.files import ensure_dir
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+DEFAULT_OUTPUT_ROOT = REPO_ROOT / "outputs" / "training_bundles"
+DEFAULT_DATASET_ENV_VAR = "TAAC_DATASET_PATH"
+DEFAULT_OUTPUT_ENV_VAR = "TAAC_OUTPUT_DIR"
+DEFAULT_WORKDIR_ENV_VAR = "TAAC_BUNDLE_WORKDIR"
+DEFAULT_ENABLE_TE_ENV_VAR = "TAAC_ENABLE_TE"
+DEFAULT_FORCE_EXTRACT_ENV_VAR = "TAAC_FORCE_EXTRACT"
+PAYLOAD_ARCHIVE_NAME = "runtime_payload.tar.gz"
+PAYLOAD_PROJECT_DIRNAME = "project"
+TEMPLATE_PACKAGE = "taac2026.application.maintenance.templates"
+
+RUNTIME_TREE_RELATIVE_PATHS = (
+    Path("src/taac2026/domain"),
+    Path("src/taac2026/infrastructure"),
+    Path("src/taac2026/application/training"),
+)
+
+RUNTIME_FILE_RELATIVE_PATHS = (
+    Path("src/taac2026/__init__.py"),
+    Path("src/taac2026/application/__init__.py"),
+)
+
+
+@dataclass(slots=True)
+class TrainingBundleResult:
+    output_path: Path
+    bundle_name: str
+    experiment_argument: str
+    bundled_experiment_path: str
+    payload_file_count: int
+    payload_size_bytes: int
+    archive_size_bytes: int
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Bundle a TAAC 2026 experiment into a single zip for online training",
+    )
+    parser.add_argument("--experiment", required=True, help="Experiment package under config/, such as config/baseline")
+    parser.add_argument(
+        "--output",
+        help="Zip file to create. Defaults to outputs/training_bundles/<bundle-name>.zip",
+    )
+    parser.add_argument(
+        "--bundle-name",
+        help="Override the generated bundle name used for the output filename and metadata.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite the output zip if it already exists.",
+    )
+    return parser.parse_args(argv)
+
+
+def _slugify(value: str) -> str:
+    collapsed = re.sub(r"[^a-zA-Z0-9]+", "-", value.strip().lower()).strip("-")
+    return collapsed or "training-bundle"
+
+
+def _normalize_experiment_relative_path(experiment_argument: str) -> Path:
+    raw_value = experiment_argument.strip()
+    if not raw_value:
+        raise ValueError("--experiment must not be empty")
+
+    candidate = Path(raw_value).expanduser()
+    repo_candidate = candidate if candidate.is_absolute() else (REPO_ROOT / candidate)
+    if candidate.exists() or repo_candidate.exists():
+        resolved = candidate.resolve() if candidate.exists() else repo_candidate.resolve()
+        if resolved.is_file():
+            if resolved.name != "__init__.py":
+                raise ValueError("--experiment must point to a config package directory or its __init__.py")
+            resolved = resolved.parent
+        try:
+            relative = resolved.relative_to(REPO_ROOT)
+        except ValueError as exc:
+            raise ValueError("--experiment must resolve inside this repository") from exc
+    else:
+        module_parts = raw_value.split(".")
+        if len(module_parts) < 2 or module_parts[0] != "config":
+            raise ValueError("--experiment must be a config/ path or config.<name> module path")
+        relative = Path(*module_parts)
+
+    if not relative.parts or relative.parts[0] != "config":
+        raise ValueError("--experiment must resolve under config/")
+
+    experiment_dir = REPO_ROOT / relative
+    if not experiment_dir.is_dir():
+        raise ValueError(f"experiment package directory not found: {experiment_dir}")
+    if not (experiment_dir / "__init__.py").exists():
+        raise ValueError(f"experiment package is missing __init__.py: {experiment_dir}")
+    return relative
+
+
+def _read_template(template_name: str) -> str:
+    return files(TEMPLATE_PACKAGE).joinpath(*template_name.split("/")).read_text(encoding="utf-8")
+
+
+def _render_template(template_name: str, replacements: dict[str, str]) -> str:
+    rendered = _read_template(template_name)
+    for key, value in replacements.items():
+        rendered = rendered.replace(f"{{{{{key}}}}}", value)
+    unresolved = re.findall(r"\{\{[a-zA-Z0-9_]+\}\}", rendered)
+    if unresolved:
+        placeholder_list = ", ".join(sorted(set(unresolved)))
+        raise ValueError(f"Template {template_name} has unresolved placeholders: {placeholder_list}")
+    return rendered
+
+
+def _render_run_sh(bundled_experiment_path: str) -> str:
+    return _render_template(
+        "run.sh.tmpl",
+        {
+            "payload_archive_name": PAYLOAD_ARCHIVE_NAME,
+            "payload_project_dirname": PAYLOAD_PROJECT_DIRNAME,
+            "dataset_env_var": DEFAULT_DATASET_ENV_VAR,
+            "workdir_expr": f"${{{DEFAULT_WORKDIR_ENV_VAR}:-$SCRIPT_DIR/runtime}}",
+            "dataset_path_expr": f"${{{DEFAULT_DATASET_ENV_VAR}:-}}",
+            "output_dir_expr": f"${{{DEFAULT_OUTPUT_ENV_VAR}:-$SCRIPT_DIR/outputs}}",
+            "enable_te_expr": f"${{{DEFAULT_ENABLE_TE_ENV_VAR}:-0}}",
+            "force_extract_expr": f"${{{DEFAULT_FORCE_EXTRACT_ENV_VAR}:-0}}",
+            "bundled_experiment_path": bundled_experiment_path,
+        },
+    )
+
+
+def _render_readme(bundle_name: str, bundled_experiment_path: str) -> str:
+    return _render_template(
+        "bundle_readme.md.tmpl",
+        {
+            "bundle_name": bundle_name,
+            "payload_archive_name": PAYLOAD_ARCHIVE_NAME,
+            "dataset_env_var": DEFAULT_DATASET_ENV_VAR,
+            "output_env_var": DEFAULT_OUTPUT_ENV_VAR,
+            "workdir_env_var": DEFAULT_WORKDIR_ENV_VAR,
+            "enable_te_env_var": DEFAULT_ENABLE_TE_ENV_VAR,
+            "force_extract_env_var": DEFAULT_FORCE_EXTRACT_ENV_VAR,
+            "dataset_env_reference": f"${{{DEFAULT_DATASET_ENV_VAR}}}",
+            "output_env_reference": f"${{{DEFAULT_OUTPUT_ENV_VAR}}}",
+            "bundled_experiment_path": bundled_experiment_path,
+        },
+    )
+
+
+def _ignore_copy_junk(_directory: str, names: list[str]) -> set[str]:
+    return {name for name in names if name == "__pycache__" or name.endswith((".pyc", ".pyo"))}
+
+
+def _copy_relative_path(relative_path: Path, destination_root: Path) -> None:
+    source = REPO_ROOT / relative_path
+    destination = destination_root / relative_path
+    if source.is_dir():
+        shutil.copytree(source, destination, dirs_exist_ok=True, ignore=_ignore_copy_junk)
+        return
+    ensure_dir(destination.parent)
+    shutil.copy2(source, destination)
+
+
+def _count_files(root: Path) -> int:
+    return sum(1 for path in root.rglob("*") if path.is_file())
+
+
+def _count_bytes(root: Path) -> int:
+    return sum(path.stat().st_size for path in root.rglob("*") if path.is_file())
+
+
+def _write_text(path: Path, content: str) -> None:
+    ensure_dir(path.parent)
+    path.write_text(content, encoding="utf-8")
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    _write_text(path, json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n")
+
+
+def _write_payload_archive(payload_root: Path, output_path: Path) -> None:
+    ensure_dir(output_path.parent)
+    with tarfile.open(output_path, mode="w:gz") as archive:
+        archive.add(payload_root, arcname=PAYLOAD_PROJECT_DIRNAME)
+
+
+def _write_zip(bundle_root: Path, output_path: Path) -> None:
+    ensure_dir(output_path.parent)
+    with zipfile.ZipFile(output_path, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for path in sorted(bundle_root.rglob("*")):
+            if path.is_dir():
+                continue
+            archive.write(path, arcname=path.relative_to(bundle_root).as_posix())
+
+
+def build_training_bundle(
+    experiment_argument: str,
+    *,
+    output_path: str | Path | None = None,
+    bundle_name: str | None = None,
+    force: bool = False,
+) -> TrainingBundleResult:
+    experiment_relative_path = _normalize_experiment_relative_path(experiment_argument)
+    normalized_bundle_name = _slugify(bundle_name or f"{experiment_relative_path.name}-train-bundle")
+    target_path = Path(output_path).expanduser() if output_path is not None else DEFAULT_OUTPUT_ROOT / f"{normalized_bundle_name}.zip"
+
+    if target_path.exists() and not force:
+        raise FileExistsError(f"output zip already exists: {target_path}")
+
+    with tempfile.TemporaryDirectory(prefix="taac_train_bundle_") as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        payload_root = temp_dir / PAYLOAD_PROJECT_DIRNAME
+        bundle_root = temp_dir / "bundle"
+        bundle_root.mkdir(parents=True, exist_ok=True)
+
+        for relative_path in RUNTIME_TREE_RELATIVE_PATHS:
+            _copy_relative_path(relative_path, payload_root)
+        for relative_path in RUNTIME_FILE_RELATIVE_PATHS:
+            _copy_relative_path(relative_path, payload_root)
+        _copy_relative_path(experiment_relative_path, payload_root)
+        _copy_relative_path(Path("pyproject.toml"), payload_root)
+        _copy_relative_path(Path("README.md"), payload_root)
+
+        payload_archive = bundle_root / PAYLOAD_ARCHIVE_NAME
+        _write_payload_archive(payload_root, payload_archive)
+
+        bundled_experiment_path = experiment_relative_path.as_posix()
+        run_sh_path = bundle_root / "run.sh"
+        _write_text(run_sh_path, _render_run_sh(bundled_experiment_path))
+        run_sh_path.chmod(0o755)
+        _write_text(bundle_root / "README.md", _render_readme(normalized_bundle_name, bundled_experiment_path))
+
+        archive_path = target_path if target_path.is_absolute() else (REPO_ROOT / target_path)
+        archive_path = archive_path.resolve()
+
+        payload_file_count = _count_files(payload_root)
+        payload_size_bytes = _count_bytes(payload_root)
+        manifest = {
+            "schema_version": 1,
+            "bundle_name": normalized_bundle_name,
+            "experiment_argument": experiment_argument,
+            "bundled_experiment_path": bundled_experiment_path,
+            "payload_archive": PAYLOAD_ARCHIVE_NAME,
+            "payload_root": PAYLOAD_PROJECT_DIRNAME,
+            "entrypoint": "run.sh",
+            "runtime_env": {
+                "dataset_path": DEFAULT_DATASET_ENV_VAR,
+                "output_dir": DEFAULT_OUTPUT_ENV_VAR,
+                "workdir": DEFAULT_WORKDIR_ENV_VAR,
+                "enable_te": DEFAULT_ENABLE_TE_ENV_VAR,
+                "force_extract": DEFAULT_FORCE_EXTRACT_ENV_VAR,
+            },
+            "payload_stats": {
+                "file_count": payload_file_count,
+                "size_bytes": payload_size_bytes,
+            },
+        }
+        _write_json(bundle_root / "bundle_manifest.json", manifest)
+
+        temp_archive_path = temp_dir / "bundle.zip"
+        _write_zip(bundle_root, temp_archive_path)
+        ensure_dir(archive_path.parent)
+        shutil.move(str(temp_archive_path), str(archive_path))
+
+    return TrainingBundleResult(
+        output_path=archive_path,
+        bundle_name=normalized_bundle_name,
+        experiment_argument=experiment_argument,
+        bundled_experiment_path=bundled_experiment_path,
+        payload_file_count=payload_file_count,
+        payload_size_bytes=payload_size_bytes,
+        archive_size_bytes=archive_path.stat().st_size,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        result = build_training_bundle(
+            args.experiment,
+            output_path=args.output,
+            bundle_name=args.bundle_name,
+            force=args.force,
+        )
+    except (FileExistsError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    print_summary_table(
+        "taac-package-train",
+        [
+            ("bundle_name", result.bundle_name),
+            ("experiment", result.experiment_argument),
+            ("bundled_experiment", result.bundled_experiment_path),
+            ("payload_files", result.payload_file_count),
+            ("payload_size_bytes", result.payload_size_bytes),
+            ("archive_size_bytes", result.archive_size_bytes),
+            ("output", result.output_path),
+        ],
+    )
+    return 0
+
+
+__all__ = ["TrainingBundleResult", "build_training_bundle", "main", "parse_args"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/taac2026/application/maintenance/package_training.py
+++ b/src/taac2026/application/maintenance/package_training.py
@@ -216,9 +216,14 @@ def build_training_bundle(
     experiment_relative_path = _normalize_experiment_relative_path(experiment_argument)
     normalized_bundle_name = _slugify(bundle_name or f"{experiment_relative_path.name}-train-bundle")
     target_path = Path(output_path).expanduser() if output_path is not None else DEFAULT_OUTPUT_ROOT / f"{normalized_bundle_name}.zip"
+    archive_path = target_path if target_path.is_absolute() else (REPO_ROOT / target_path)
+    archive_path = archive_path.resolve()
 
-    if target_path.exists() and not force:
-        raise FileExistsError(f"output zip already exists: {target_path}")
+    if archive_path.exists():
+        if archive_path.is_dir():
+            raise IsADirectoryError(f"output path is a directory: {archive_path}")
+        if not force:
+            raise FileExistsError(f"output zip already exists: {archive_path}")
 
     with tempfile.TemporaryDirectory(prefix="taac_train_bundle_") as temp_dir_name:
         temp_dir = Path(temp_dir_name)
@@ -232,6 +237,7 @@ def build_training_bundle(
             _copy_relative_path(relative_path, payload_root)
         _copy_relative_path(experiment_relative_path, payload_root)
         _copy_relative_path(Path("pyproject.toml"), payload_root)
+        _copy_relative_path(Path("uv.lock"), payload_root)
         _copy_relative_path(Path("README.md"), payload_root)
 
         payload_archive = bundle_root / PAYLOAD_ARCHIVE_NAME
@@ -243,9 +249,6 @@ def build_training_bundle(
         run_sh_path.chmod(0o755)
         _write_text(bundle_root / "README.md", _render_readme(normalized_bundle_name, bundled_experiment_path))
 
-        archive_path = target_path if target_path.is_absolute() else (REPO_ROOT / target_path)
-        archive_path = archive_path.resolve()
-
         payload_file_count = _count_files(payload_root)
         payload_size_bytes = _count_bytes(payload_root)
         manifest = {
@@ -256,6 +259,7 @@ def build_training_bundle(
             "payload_archive": PAYLOAD_ARCHIVE_NAME,
             "payload_root": PAYLOAD_PROJECT_DIRNAME,
             "entrypoint": "run.sh",
+            "lockfile": "uv.lock",
             "runtime_env": {
                 "dataset_path": DEFAULT_DATASET_ENV_VAR,
                 "output_dir": DEFAULT_OUTPUT_ENV_VAR,
@@ -273,6 +277,8 @@ def build_training_bundle(
         temp_archive_path = temp_dir / "bundle.zip"
         _write_zip(bundle_root, temp_archive_path)
         ensure_dir(archive_path.parent)
+        if archive_path.exists():
+            archive_path.unlink()
         shutil.move(str(temp_archive_path), str(archive_path))
 
     return TrainingBundleResult(
@@ -295,7 +301,7 @@ def main(argv: list[str] | None = None) -> int:
             bundle_name=args.bundle_name,
             force=args.force,
         )
-    except (FileExistsError, ValueError) as exc:
+    except (FileExistsError, IsADirectoryError, ValueError) as exc:
         print(str(exc), file=sys.stderr)
         return 2
 

--- a/src/taac2026/application/maintenance/templates/__init__.py
+++ b/src/taac2026/application/maintenance/templates/__init__.py
@@ -1,0 +1,1 @@
+"""Template resources for maintenance CLIs."""

--- a/src/taac2026/application/maintenance/templates/bundle_readme.md.tmpl
+++ b/src/taac2026/application/maintenance/templates/bundle_readme.md.tmpl
@@ -1,0 +1,22 @@
+# {{bundle_name}}
+
+这个压缩包用于把 TAAC 2026 的单个实验包上传到线上训练环境。
+
+包含内容：
+- run.sh：自动解压运行时 payload、安装依赖并启动训练。
+- {{payload_archive_name}}：最小训练源码和指定实验包。
+- bundle_manifest.json：打包元数据。
+
+使用方式：
+1. 解压 zip，进入解压后的目录。
+2. 设置 {{dataset_env_var}} 指向线上数据目录或 parquet 文件。
+3. 可选设置 {{output_env_var}} 指定训练产物输出目录。
+4. 执行 bash run.sh，可继续追加训练参数，例如 --compile --amp --amp-dtype bfloat16。
+
+默认训练命令等价于：
+uv run taac-train --experiment ./{{bundled_experiment_path}} --dataset-path "{{dataset_env_reference}}" --run-dir "{{output_env_reference}}"
+
+可选环境变量：
+- {{workdir_env_var}}：控制 payload 解压后的工作目录。
+- {{enable_te_env_var}}=1：安装并启用 transformer-engine 额外依赖。
+- {{force_extract_env_var}}=1：强制重新解压 payload。

--- a/src/taac2026/application/maintenance/templates/bundle_readme.md.tmpl
+++ b/src/taac2026/application/maintenance/templates/bundle_readme.md.tmpl
@@ -7,6 +7,8 @@
 - {{payload_archive_name}}：最小训练源码和指定实验包。
 - bundle_manifest.json：打包元数据。
 
+其中 {{payload_archive_name}} 解压后包含 `pyproject.toml`、`uv.lock` 和最小训练源码，用于执行锁定依赖安装。
+
 使用方式：
 1. 解压 zip，进入解压后的目录。
 2. 设置 {{dataset_env_var}} 指向线上数据目录或 parquet 文件。

--- a/src/taac2026/application/maintenance/templates/run.sh.tmpl
+++ b/src/taac2026/application/maintenance/templates/run.sh.tmpl
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ARCHIVE_PATH="$SCRIPT_DIR/{{payload_archive_name}}"
+WORKDIR="{{workdir_expr}}"
+PROJECT_DIR="$WORKDIR/{{payload_project_dirname}}"
+DATASET_PATH="{{dataset_path_expr}}"
+OUTPUT_DIR="{{output_dir_expr}}"
+ENABLE_TE="{{enable_te_expr}}"
+FORCE_EXTRACT="{{force_extract_expr}}"
+
+if [[ -z "$DATASET_PATH" ]]; then
+    echo "{{dataset_env_var}} must point to a parquet file or dataset cache directory." >&2
+    exit 2
+fi
+
+if [[ ! -f "$ARCHIVE_PATH" ]]; then
+    echo "runtime payload archive not found: $ARCHIVE_PATH" >&2
+    exit 2
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+    echo "uv is required on PATH before running this bundle." >&2
+    exit 2
+fi
+
+if [[ "$FORCE_EXTRACT" == "1" ]]; then
+    rm -rf "$PROJECT_DIR"
+fi
+
+mkdir -p "$WORKDIR"
+if [[ ! -d "$PROJECT_DIR" ]]; then
+    tar -xzf "$ARCHIVE_PATH" -C "$WORKDIR"
+fi
+
+cd "$PROJECT_DIR"
+
+UV_SYNC_ARGS=(sync)
+if [[ "$ENABLE_TE" == "1" ]]; then
+    UV_SYNC_ARGS+=(--extra te)
+fi
+
+uv "${UV_SYNC_ARGS[@]}"
+uv run taac-train --experiment "./{{bundled_experiment_path}}" --dataset-path "$DATASET_PATH" --run-dir "$OUTPUT_DIR" "$@"

--- a/src/taac2026/application/maintenance/templates/run.sh.tmpl
+++ b/src/taac2026/application/maintenance/templates/run.sh.tmpl
@@ -36,10 +36,10 @@ fi
 
 cd "$PROJECT_DIR"
 
-UV_SYNC_ARGS=(sync)
+UV_SYNC_EXTRA_ARGS=()
 if [[ "$ENABLE_TE" == "1" ]]; then
-    UV_SYNC_ARGS+=(--extra te)
+    UV_SYNC_EXTRA_ARGS+=(--extra te)
 fi
 
-uv "${UV_SYNC_ARGS[@]}"
+uv sync --locked "${UV_SYNC_EXTRA_ARGS[@]}"
 uv run taac-train --experiment "./{{bundled_experiment_path}}" --dataset-path "$DATASET_PATH" --run-dir "$OUTPUT_DIR" "$@"

--- a/src/taac2026/application/training/cli.py
+++ b/src/taac2026/application/training/cli.py
@@ -10,6 +10,7 @@ from ...infrastructure.io.console import configure_logging, print_summary_table
 def parse_train_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Train a TAAC 2026 experiment")
     parser.add_argument("--experiment", required=True, help="Experiment package path or module path")
+    parser.add_argument("--dataset-path", help="Override dataset path")
     parser.add_argument("--run-dir", help="Override output directory")
     parser.add_argument("--compile", action="store_true", help="Enable torch.compile for model execution")
     parser.add_argument("--compile-backend", help="Override torch.compile backend")
@@ -25,6 +26,8 @@ def main(argv: list[str] | None = None) -> int:
     configure_logging()
     args = parse_train_args(argv)
     experiment = load_experiment_package(args.experiment)
+    if args.dataset_path:
+        experiment.data.dataset_path = args.dataset_path
     if args.run_dir:
         experiment.train.output_dir = args.run_dir
     if args.compile:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ UNIT_TEST_FILES = {
     "test_metrics.py",
     "test_model_performance_plot.py",
     "test_norms.py",
+    "test_package_training.py",
     "test_property_based.py",
     "test_payload.py",
     "test_pooling_heads.py",

--- a/tests/test_package_training.py
+++ b/tests/test_package_training.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from io import BytesIO
+from pathlib import Path
+import tarfile
+import zipfile
+
+import pytest
+
+from taac2026.application.maintenance.package_training import build_training_bundle
+
+
+def _read_payload_names(bundle_path: Path) -> set[str]:
+    with zipfile.ZipFile(bundle_path) as bundle_archive:
+        payload_bytes = bundle_archive.read("runtime_payload.tar.gz")
+    with tarfile.open(fileobj=BytesIO(payload_bytes), mode="r:gz") as payload_archive:
+        return {member.name for member in payload_archive.getmembers()}
+
+
+def test_build_training_bundle_writes_single_zip_with_expected_layout(tmp_path: Path) -> None:
+    output_path = tmp_path / "baseline_bundle.zip"
+
+    result = build_training_bundle("config/baseline", output_path=output_path)
+
+    assert result.output_path == output_path.resolve()
+    assert output_path.exists()
+
+    with zipfile.ZipFile(output_path) as bundle_archive:
+        names = set(bundle_archive.namelist())
+        assert {"README.md", "bundle_manifest.json", "run.sh", "runtime_payload.tar.gz"} <= names
+        run_sh = bundle_archive.read("run.sh").decode("utf-8")
+        manifest = bundle_archive.read("bundle_manifest.json").decode("utf-8")
+
+    assert "TAAC_DATASET_PATH" in run_sh
+    assert 'uv run taac-train --experiment "./config/baseline"' in run_sh
+    assert '"bundled_experiment_path": "config/baseline"' in manifest
+
+
+def test_build_training_bundle_payload_is_trimmed_to_training_runtime(tmp_path: Path) -> None:
+    output_path = tmp_path / "baseline_bundle.zip"
+    build_training_bundle("config.baseline", output_path=output_path)
+
+    payload_names = _read_payload_names(output_path)
+
+    assert "project/config/baseline/__init__.py" in payload_names
+    assert "project/src/taac2026/application/training/cli.py" in payload_names
+    assert "project/src/taac2026/infrastructure/io/files.py" in payload_names
+    assert "project/src/taac2026/application/search/cli.py" not in payload_names
+    assert "project/tests/test_package_training.py" not in payload_names
+    assert "project/docs/getting-started.md" not in payload_names
+
+
+def test_build_training_bundle_copies_root_pyproject_and_readme(tmp_path: Path) -> None:
+    output_path = tmp_path / "baseline_bundle.zip"
+    build_training_bundle("config/baseline", output_path=output_path)
+
+    with zipfile.ZipFile(output_path) as bundle_archive:
+        payload_bytes = bundle_archive.read("runtime_payload.tar.gz")
+    with tarfile.open(fileobj=BytesIO(payload_bytes), mode="r:gz") as payload_archive:
+        pyproject_member = payload_archive.extractfile("project/pyproject.toml")
+        assert pyproject_member is not None
+        pyproject_text = pyproject_member.read().decode("utf-8")
+
+        readme_member = payload_archive.extractfile("project/README.md")
+        assert readme_member is not None
+        payload_readme_text = readme_member.read().decode("utf-8")
+
+    source_pyproject_text = (Path(__file__).resolve().parents[1] / "pyproject.toml").read_text(encoding="utf-8")
+    source_readme_text = (Path(__file__).resolve().parents[1] / "README.md").read_text(encoding="utf-8")
+
+    assert pyproject_text == source_pyproject_text
+    assert payload_readme_text == source_readme_text
+
+
+def test_build_training_bundle_refuses_to_overwrite_existing_output_without_force(tmp_path: Path) -> None:
+    output_path = tmp_path / "baseline_bundle.zip"
+    build_training_bundle("config/baseline", output_path=output_path)
+
+    with pytest.raises(FileExistsError, match="output zip already exists"):
+        build_training_bundle("config/baseline", output_path=output_path)

--- a/tests/test_package_training.py
+++ b/tests/test_package_training.py
@@ -32,8 +32,10 @@ def test_build_training_bundle_writes_single_zip_with_expected_layout(tmp_path: 
         manifest = bundle_archive.read("bundle_manifest.json").decode("utf-8")
 
     assert "TAAC_DATASET_PATH" in run_sh
+    assert "uv sync --locked" in run_sh
     assert 'uv run taac-train --experiment "./config/baseline"' in run_sh
     assert '"bundled_experiment_path": "config/baseline"' in manifest
+    assert '"lockfile": "uv.lock"' in manifest
 
 
 def test_build_training_bundle_payload_is_trimmed_to_training_runtime(tmp_path: Path) -> None:
@@ -45,6 +47,7 @@ def test_build_training_bundle_payload_is_trimmed_to_training_runtime(tmp_path: 
     assert "project/config/baseline/__init__.py" in payload_names
     assert "project/src/taac2026/application/training/cli.py" in payload_names
     assert "project/src/taac2026/infrastructure/io/files.py" in payload_names
+    assert "project/uv.lock" in payload_names
     assert "project/src/taac2026/application/search/cli.py" not in payload_names
     assert "project/tests/test_package_training.py" not in payload_names
     assert "project/docs/getting-started.md" not in payload_names
@@ -61,14 +64,20 @@ def test_build_training_bundle_copies_root_pyproject_and_readme(tmp_path: Path) 
         assert pyproject_member is not None
         pyproject_text = pyproject_member.read().decode("utf-8")
 
+        lockfile_member = payload_archive.extractfile("project/uv.lock")
+        assert lockfile_member is not None
+        payload_lockfile_text = lockfile_member.read().decode("utf-8")
+
         readme_member = payload_archive.extractfile("project/README.md")
         assert readme_member is not None
         payload_readme_text = readme_member.read().decode("utf-8")
 
     source_pyproject_text = (Path(__file__).resolve().parents[1] / "pyproject.toml").read_text(encoding="utf-8")
+    source_lockfile_text = (Path(__file__).resolve().parents[1] / "uv.lock").read_text(encoding="utf-8")
     source_readme_text = (Path(__file__).resolve().parents[1] / "README.md").read_text(encoding="utf-8")
 
     assert pyproject_text == source_pyproject_text
+    assert payload_lockfile_text == source_lockfile_text
     assert payload_readme_text == source_readme_text
 
 
@@ -78,3 +87,22 @@ def test_build_training_bundle_refuses_to_overwrite_existing_output_without_forc
 
     with pytest.raises(FileExistsError, match="output zip already exists"):
         build_training_bundle("config/baseline", output_path=output_path)
+
+
+def test_build_training_bundle_force_replaces_existing_output_file(tmp_path: Path) -> None:
+    output_path = tmp_path / "baseline_bundle.zip"
+    output_path.write_text("stale", encoding="utf-8")
+
+    result = build_training_bundle("config/baseline", output_path=output_path, force=True)
+
+    assert result.output_path == output_path.resolve()
+    with zipfile.ZipFile(output_path) as bundle_archive:
+        assert "run.sh" in bundle_archive.namelist()
+
+
+def test_build_training_bundle_rejects_directory_output_path(tmp_path: Path) -> None:
+    output_dir = tmp_path / "bundle_dir"
+    output_dir.mkdir()
+
+    with pytest.raises(IsADirectoryError, match="output path is a directory"):
+        build_training_bundle("config/baseline", output_path=output_dir, force=True)

--- a/tests/test_runtime_optimization.py
+++ b/tests/test_runtime_optimization.py
@@ -130,3 +130,16 @@ def test_parse_train_args_accepts_runtime_optimization_flags() -> None:
     assert args.compile_mode == "max-autotune"
     assert args.amp is True
     assert args.amp_dtype == "bfloat16"
+
+
+def test_parse_train_args_accepts_dataset_path_override() -> None:
+    args = parse_train_args(
+        [
+            "--experiment",
+            "config/baseline",
+            "--dataset-path",
+            "/tmp/online-data",
+        ]
+    )
+
+    assert args.dataset_path == "/tmp/online-data"

--- a/zensical.toml
+++ b/zensical.toml
@@ -40,6 +40,7 @@ nav = [
         { "TAAC 2025 论文洞察" = "analysis/taac2025-insights.md" },
     ] },
     { "指南" = [
+        { "线上训练打包" = "guide/online-training-bundle.md" },
         { "超参数搜索" = "guide/search.md" },
         { "测试" = "guide/testing.md" },
         { "开发容器 (WSL2 + Docker)" = "guide/devcontainer.md" },


### PR DESCRIPTION
## Summary
- add `taac-package-train` to bundle a single experiment package into an uploadable online-training zip
- add `--dataset-path` runtime override to `taac-train` so bundled runs can use external mounted data
- document the online training bundle workflow in README, quick start, docs index, and a dedicated guide page
- add focused tests for bundle generation and train CLI argument parsing

## Why
Issue #25 requires a lightweight packaging flow for online training where code must be uploaded manually. This PR adds a single-zip bundle format with a shell entrypoint and keeps the bundle aligned with the repository's real project metadata by copying the root `pyproject.toml` and `README.md` into the payload.

## Validation
- `uv run pytest tests/test_runtime_optimization.py tests/test_package_training.py -q`
- generated a real baseline bundle with `uv run taac-package-train --experiment config/baseline`
- extracted the payload and confirmed the copied root `pyproject.toml` can still build a wheel successfully

Fixes #25