### PR TITLE
Fix #36: migrate int8 inference quantization to torchao

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -121,7 +121,7 @@ graph TD
 - `optimizers.py`：`Muon`、`CombinedOptimizer`、`build_hybrid_optimizer()`
 - `transformer.py`：`TaacTransformerBlock`、`TaacCrossAttentionBlock`
 - `hstu.py`：`HSTUBlock`、`TimeAwareHSTU`、`BranchTransducer`、`MixtureOfTransducers`、`BlockAttnRes`、时间偏置 / RoPE helper
-- `quantization.py`：评估侧动态 int8 量化入口（`nn.Linear` + `EmbeddingBagCollection`）
+- `quantization.py`：评估侧动态 int8 量化入口（torchao `nn.Linear` 主路径；TorchRec `EmbeddingBagCollection` 显式不支持 int8）
 - `triton_norm.py`：首个 Triton RMSNorm kernel 与测试支架
 
 这些组件已经覆盖了主干里的共享注意力、RMSNorm、HSTU 与混合优化器路径；当前未完成的重点收尾转为 fp8 kernel，以及基于 benchmark 的最终验收报告。

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -108,7 +108,7 @@ uv run taac-evaluate single --experiment config/baseline --compile --amp --amp-d
 
 评估报告包含：AUC、PR-AUC、Brier Score、LogLoss、GAUC，以及推理延迟（ms/sample）。
 
-`--quantize int8` 当前会把推理切到 CPU，并对 `nn.Linear` 与 TorchRec `EmbeddingBagCollection` 应用动态 int8 量化；这条路径适合本地或 CI 的推理回归验证，不会修改训练 checkpoint 本身。
+`--quantize int8` 当前会把推理切到 CPU，并通过 torchao 对 `nn.Linear` 应用动态 int8 量化；如果模型包含 TorchRec `EmbeddingBagCollection`，评估会直接拒绝这条 int8 路径并要求回退到 `--quantize none`。这条路径适合本地或 CI 的推理回归验证，不会修改训练 checkpoint 本身。
 
 `--export-mode torch-export` 会基于当前评估 batch 生成 `.pt2` artifact，默认输出到评估输出目录，可用于后续 AOTI / runtime backend 集成验证。
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
 	"pytest-benchmark>=5.1",
 	"rich>=13.9",
 	"torch>=2.6; platform_system == 'Linux'",
+	"torchao>=0.17; platform_system == 'Linux'",
 	"triton>=3.2; platform_system == 'Linux'",
 	"torchrec>=1.0; platform_system == 'Linux'",
 ]
@@ -32,6 +33,9 @@ te = [
 
 [tool.uv.sources]
 torch = [
+	{ index = "pytorch-cu128", marker = "platform_system == 'Linux'" },
+]
+torchao = [
 	{ index = "pytorch-cu128", marker = "platform_system == 'Linux'" },
 ]
 "fbgemm-gpu" = [

--- a/scripts/verify_gpu_env.py
+++ b/scripts/verify_gpu_env.py
@@ -6,12 +6,14 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+from pathlib import Path
 import sys
 
 logging.getLogger().setLevel(logging.ERROR)
 
 import fbgemm_gpu
 import torch
+import torchao
 import torchrec
 import triton
 
@@ -57,6 +59,25 @@ def _run_embedding_probe(device: torch.device) -> dict[str, object]:
     }
 
 
+def _run_torchao_extension_probe() -> dict[str, object]:
+    extension_paths = sorted(Path(torchao.__file__).resolve().parent.glob("_C*.so"))
+    if not extension_paths:
+        raise RuntimeError("torchao package does not expose any native extensions")
+
+    loaded: list[str] = []
+    for extension_path in extension_paths:
+        try:
+            torch.ops.load_library(str(extension_path))
+        except OSError as exc:
+            raise RuntimeError(f"Failed to load torchao native extension {extension_path.name}: {exc}") from exc
+        loaded.append(extension_path.name)
+
+    return {
+        "count": len(loaded),
+        "loaded": loaded,
+    }
+
+
 def build_report(allow_missing_gpu: bool) -> dict[str, object]:
     cuda_available = torch.cuda.is_available()
     if not cuda_available and not allow_missing_gpu:
@@ -73,6 +94,7 @@ def build_report(allow_missing_gpu: bool) -> dict[str, object]:
     return {
         "python": sys.version.split()[0],
         "torch": torch.__version__,
+        "torchao": getattr(torchao, "__version__", "unknown"),
         "torchrec": getattr(torchrec, "__version__", "unknown"),
         "fbgemm_gpu": getattr(fbgemm_gpu, "__version__", "unknown"),
         "triton": getattr(triton, "__version__", "unknown"),
@@ -82,11 +104,12 @@ def build_report(allow_missing_gpu: bool) -> dict[str, object]:
         "gpu_precision": detect_precision_support(device if cuda_available else None),
         "transformer_engine": detect_transformer_engine_availability(device if cuda_available else None),
         "embedding_probe": probe,
+        "torchao_extensions": _run_torchao_extension_probe() if cuda_available else None,
     }
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Verify CUDA + torch + torchrec + fbgemm-gpu + triton")
+    parser = argparse.ArgumentParser(description="Verify CUDA + torch + torchao + torchrec + fbgemm-gpu + triton")
     parser.add_argument("--allow-missing-gpu", action="store_true", help="Succeed on CPU-only hosts")
     parser.add_argument("--json", action="store_true", help="Print a JSON report")
     args = parser.parse_args()
@@ -97,6 +120,7 @@ def main() -> int:
     else:
         print(f"python        : {report['python']}")
         print(f"torch         : {report['torch']}")
+        print(f"torchao       : {report['torchao']}")
         print(f"torchrec      : {report['torchrec']}")
         print(f"fbgemm_gpu    : {report['fbgemm_gpu']}")
         print(f"triton        : {report['triton']}")
@@ -105,6 +129,7 @@ def main() -> int:
         print(f"gpu_precision : {report['gpu_precision']}")
         print(f"transformer_engine: {report['transformer_engine']}")
         print(f"embedding     : {report['embedding_probe']}")
+        print(f"torchao_ext   : {report['torchao_extensions']}")
     return 0
 
 

--- a/src/taac2026/application/evaluation/cli.py
+++ b/src/taac2026/application/evaluation/cli.py
@@ -32,6 +32,43 @@ def _apply_runtime_optimization_args(experiment, args: argparse.Namespace) -> No
         experiment.train.amp_dtype = args.amp_dtype
 
 
+def _format_quantization_summary(summary: dict[str, Any]) -> str:
+    mode = str(summary.get("mode", "none"))
+    if mode == "none":
+        return mode
+
+    parts = [mode]
+    quantized_linear_layers = int(summary.get("quantized_linear_layers", 0) or 0)
+    active = summary.get("active")
+    resolved_active = bool(active) if active is not None else quantized_linear_layers > 0
+    if not resolved_active:
+        parts.append("inactive")
+        return " | ".join(parts)
+
+    if quantized_linear_layers > 0:
+        parts.append(f"linear={quantized_linear_layers}")
+    return " | ".join(parts)
+
+
+def _build_single_summary_rows(report: dict[str, Any]) -> list[tuple[str, Any]]:
+    quantization = report["quantization"]
+    return [
+        ("experiment", report["experiment"]),
+        ("experiment_path", report["experiment_path"]),
+        ("checkpoint_path", report["checkpoint_path"]),
+        ("device", report["device"]),
+        ("quantization", _format_quantization_summary(quantization)),
+        ("quantization_reason", quantization.get("reason") or "-"),
+        ("export", report["export"]["mode"]),
+        ("export_artifact", report["export"].get("artifact_path") or "-"),
+        ("loss", f"{float(report['loss']):.6f}"),
+        ("auc", f"{float(report['metrics'].get('auc', 0.0)):.6f}"),
+        ("pr_auc", f"{float(report['metrics'].get('pr_auc', 0.0)):.6f}"),
+        ("mean_latency_ms_per_sample", f"{float(report['mean_latency_ms_per_sample']):.4f}"),
+        ("p95_latency_ms_per_sample", f"{float(report['p95_latency_ms_per_sample']):.4f}"),
+    ]
+
+
 def _print_batch_table(records: list[dict[str, Any]]) -> None:
     table = Table(title="taac-evaluate batch", box=box.SIMPLE_HEAVY, header_style="bold cyan")
     table.add_column("Rank", justify="right", style="cyan", no_wrap=True)
@@ -44,7 +81,7 @@ def _print_batch_table(records: list[dict[str, Any]]) -> None:
         table.add_row(
             str(index),
             str(record.get("experiment_path") or record.get("experiment") or record.get("model_name")),
-            str(record.get("quantization", {}).get("mode", "none")),
+            _format_quantization_summary(record.get("quantization", {})),
             f"{float(record.get('metrics', {}).get('auc', record.get('auc', 0.0))):.6f}",
             f"{float(record.get('metrics', {}).get('pr_auc', record.get('pr_auc', 0.0))):.6f}",
             f"{float(record.get('mean_latency_ms_per_sample', 0.0)):.4f}",
@@ -105,20 +142,7 @@ def main(argv: list[str] | None = None) -> int:
         )
         print_summary_table(
             "taac-evaluate single",
-            [
-                ("experiment", report["experiment"]),
-                ("experiment_path", report["experiment_path"]),
-                ("checkpoint_path", report["checkpoint_path"]),
-                ("device", report["device"]),
-                ("quantization", report["quantization"]["mode"]),
-                ("export", report["export"]["mode"]),
-                ("export_artifact", report["export"].get("artifact_path") or "-"),
-                ("loss", f"{float(report['loss']):.6f}"),
-                ("auc", f"{float(report['metrics'].get('auc', 0.0)):.6f}"),
-                ("pr_auc", f"{float(report['metrics'].get('pr_auc', 0.0)):.6f}"),
-                ("mean_latency_ms_per_sample", f"{float(report['mean_latency_ms_per_sample']):.4f}"),
-                ("p95_latency_ms_per_sample", f"{float(report['p95_latency_ms_per_sample']):.4f}"),
-            ],
+            _build_single_summary_rows(report),
         )
         return 0
 
@@ -152,4 +176,4 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
-__all__ = ["main", "parse_args"]
+__all__ = ["main", "parse_args", "_build_single_summary_rows", "_format_quantization_summary"]

--- a/src/taac2026/application/evaluation/inference.py
+++ b/src/taac2026/application/evaluation/inference.py
@@ -12,20 +12,12 @@ from ..training.runtime_optimization import RuntimeExecution, prepare_runtime_ex
 
 
 SUPPORTED_INFERENCE_EXPORT_MODES = ("none", "torch-export")
-_EXPORT_MODE_ALIASES = {
-    "off": "none",
-    "false": "none",
-    "export": "torch-export",
-    "pt2": "torch-export",
-    "torch.export": "torch-export",
-}
 
 
 def normalize_inference_export_mode(mode: str | None) -> str:
     if mode is None:
         return "none"
     normalized = str(mode).strip().lower()
-    normalized = _EXPORT_MODE_ALIASES.get(normalized, normalized)
     if normalized not in SUPPORTED_INFERENCE_EXPORT_MODES:
         supported = ", ".join(SUPPORTED_INFERENCE_EXPORT_MODES)
         raise ValueError(f"Unsupported export mode '{mode}'. Expected one of: {supported}")
@@ -42,7 +34,6 @@ def export_model_for_inference(
     resolved_mode = normalize_inference_export_mode(mode)
     if resolved_mode == "none":
         return {
-            "requested_mode": resolved_mode,
             "mode": resolved_mode,
             "active": False,
             "reason": None,
@@ -60,7 +51,6 @@ def export_model_for_inference(
     exported_program = torch.export.export(model.eval(), (example_batch,))
     torch.export.save(exported_program, resolved_output_path)
     return {
-        "requested_mode": resolved_mode,
         "mode": resolved_mode,
         "active": True,
         "reason": "captured an example-shape evaluation graph with torch.export",

--- a/src/taac2026/infrastructure/nn/quantization.py
+++ b/src/taac2026/infrastructure/nn/quantization.py
@@ -1,26 +1,21 @@
 from __future__ import annotations
 
+import copy
 from functools import lru_cache
 from typing import Any
+import warnings
 
 import torch
 from torch import nn
 
 
 SUPPORTED_QUANTIZATION_MODES = ("none", "int8")
-_QUANTIZATION_ALIASES = {
-    "off": "none",
-    "false": "none",
-    "dynamic-int8": "int8",
-    "linear-int8": "int8",
-}
 
 
 def normalize_quantization_mode(mode: str | None) -> str:
     if mode is None:
         return "none"
     normalized = str(mode).strip().lower()
-    normalized = _QUANTIZATION_ALIASES.get(normalized, normalized)
     if normalized not in SUPPORTED_QUANTIZATION_MODES:
         supported = ", ".join(SUPPORTED_QUANTIZATION_MODES)
         raise ValueError(f"Unsupported quantization mode '{mode}'. Expected one of: {supported}")
@@ -41,11 +36,13 @@ def _count_linear_layers(model: nn.Module) -> int:
     return sum(1 for module in model.modules() if isinstance(module, nn.Linear))
 
 
-def _count_dynamic_quantized_linear_layers(model: nn.Module) -> int:
+def _count_torchao_dynamic_quantized_linear_layers(model: nn.Module) -> int:
     return sum(
         1
         for module in model.modules()
-        if type(module).__name__ == "Linear" and "quantized.dynamic" in type(module).__module__
+        if isinstance(module, nn.Linear)
+        and type(module.weight).__name__ == "Int8Tensor"
+        and "torchao.quantization" in type(module.weight).__module__
     )
 
 
@@ -57,96 +54,78 @@ def _count_torchrec_embedding_bag_collections(model: nn.Module) -> int:
     )
 
 
-def _count_quantized_torchrec_embedding_bag_collections(model: nn.Module) -> int:
-    return sum(
-        1
-        for module in model.modules()
-        if type(module).__name__ == "EmbeddingBagCollection" and "torchrec.quant.embedding_modules" in type(module).__module__
-    )
-
-
 @lru_cache(maxsize=1)
-def _torchrec_dynamic_quantization_types():
-    from torchrec import EmbeddingBagCollection as TorchRecEmbeddingBagCollection
-    from torchrec.quant import EmbeddingBagCollection as QuantizedEmbeddingBagCollection
+def _torchao_dynamic_quantization_components() -> tuple[Any, type[Any]]:
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r"invalid escape sequence .*",
+            category=SyntaxWarning,
+            module=r"torchao\..*",
+        )
+        from torchao.quantization import Int8DynamicActivationInt8WeightConfig, quantize_
 
-    quantization = torch.ao.quantization
-    qconfig = quantization.QConfig(
-        activation=quantization.PlaceholderObserver,
-        weight=quantization.PlaceholderObserver.with_args(dtype=torch.qint8),
-    )
-    return TorchRecEmbeddingBagCollection, QuantizedEmbeddingBagCollection, qconfig
+    return quantize_, Int8DynamicActivationInt8WeightConfig
 
 
-def _quantize_dynamic_modules(model: nn.Module) -> nn.Module:
-    quantization = torch.ao.quantization
-    qconfig_spec: dict[type[nn.Module], Any] = {nn.Linear: quantization.default_dynamic_qconfig}
-    mapping: dict[type[nn.Module], type[nn.Module]] = {}
-
-    torchrec_embedding_bag_collection_count = _count_torchrec_embedding_bag_collections(model)
-    if torchrec_embedding_bag_collection_count > 0:
-        embedding_bag_collection_type, quantized_embedding_bag_collection_type, torchrec_qconfig = _torchrec_dynamic_quantization_types()
-        qconfig_spec[embedding_bag_collection_type] = torchrec_qconfig
-        mapping[embedding_bag_collection_type] = quantized_embedding_bag_collection_type
-
-    quantize_kwargs: dict[str, Any] = {
-        "qconfig_spec": qconfig_spec,
-        "inplace": False,
-    }
-    if mapping:
-        quantize_kwargs["mapping"] = mapping
-    return quantization.quantize_dynamic(model, **quantize_kwargs)
-
+def _quantize_linear_modules(model: nn.Module) -> nn.Module:
+    quantize_, config_type = _torchao_dynamic_quantization_components()
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r"Deprecation: .*Layout is deprecated and will be removed in a future release of torchao.*",
+            category=UserWarning,
+            module=r"torchao\..*",
+        )
+        quantize_(model, config_type(version=2))
+    return model
 
 def quantize_model_for_inference(model: nn.Module, mode: str | None) -> tuple[nn.Module, dict[str, Any]]:
     resolved_mode = normalize_quantization_mode(mode)
-    quantizable_linear_layers = _count_linear_layers(model)
-    quantizable_embedding_collections = _count_torchrec_embedding_bag_collections(model)
     if resolved_mode == "none":
         return model, {
-            "requested_mode": resolved_mode,
             "mode": resolved_mode,
             "active": False,
             "reason": None,
             "device": str(_resolve_model_device(model)),
-            "quantizable_linear_layers": quantizable_linear_layers,
-            "quantizable_embedding_collections": quantizable_embedding_collections,
             "quantized_linear_layers": 0,
-            "quantized_embedding_collections": 0,
         }
 
-    cpu_model = model.cpu().eval()
-    if quantizable_linear_layers == 0 and quantizable_embedding_collections == 0:
+    torchrec_embedding_bag_collection_count = _count_torchrec_embedding_bag_collections(model)
+    if torchrec_embedding_bag_collection_count > 0:
+        raise ValueError(
+            "dynamic int8 inference does not support TorchRec EmbeddingBagCollection modules; "
+            f"use quantization mode 'none' for models with {torchrec_embedding_bag_collection_count} collection(s)"
+        )
+
+    cpu_model = copy.deepcopy(model).cpu().eval()
+    quantizable_linear_layers = _count_linear_layers(cpu_model)
+    if quantizable_linear_layers == 0:
         return cpu_model, {
-            "requested_mode": resolved_mode,
             "mode": resolved_mode,
             "active": False,
-            "reason": "model has no nn.Linear or TorchRec EmbeddingBagCollection modules eligible for dynamic int8 quantization",
+            "reason": "model has no nn.Linear modules eligible for dynamic int8 quantization",
             "device": "cpu",
-            "quantizable_linear_layers": quantizable_linear_layers,
-            "quantizable_embedding_collections": quantizable_embedding_collections,
             "quantized_linear_layers": 0,
-            "quantized_embedding_collections": 0,
         }
 
-    quantized_model = _quantize_dynamic_modules(cpu_model)
-    quantized_linear_layers = _count_dynamic_quantized_linear_layers(quantized_model)
-    quantized_embedding_collections = _count_quantized_torchrec_embedding_bag_collections(quantized_model)
-    quantized_targets = []
-    if quantizable_linear_layers > 0:
-        quantized_targets.append("nn.Linear")
-    if quantizable_embedding_collections > 0:
-        quantized_targets.append("TorchRec EmbeddingBagCollection")
+    quantized_model = _quantize_linear_modules(cpu_model)
+    quantized_linear_layers = _count_torchao_dynamic_quantized_linear_layers(quantized_model)
+
+    reason_parts: list[str] = []
+    if quantized_linear_layers > 0:
+        reason_parts.append("dynamic int8 inference quantized nn.Linear modules via torchao on cpu")
+    else:
+        reason_parts.append(
+            "dynamic int8 inference targeted nn.Linear modules via torchao on cpu but no layers reported an Int8Tensor weight"
+        )
+
     return quantized_model, {
-        "requested_mode": resolved_mode,
         "mode": resolved_mode,
-        "active": quantized_linear_layers > 0 or quantized_embedding_collections > 0,
-        "reason": "dynamic int8 inference currently quantizes " + " and ".join(quantized_targets) + " modules on cpu",
+        "active": quantized_linear_layers > 0,
+        "reason": "; ".join(reason_parts),
         "device": "cpu",
-        "quantizable_linear_layers": quantizable_linear_layers,
-        "quantizable_embedding_collections": quantizable_embedding_collections,
         "quantized_linear_layers": quantized_linear_layers,
-        "quantized_embedding_collections": quantized_embedding_collections,
     }
 
 

--- a/tests/benchmarks/bench_inference_latency.py
+++ b/tests/benchmarks/bench_inference_latency.py
@@ -4,20 +4,9 @@ import torch
 from torch import nn
 
 from taac2026.domain.config import ModelConfig
-from taac2026.domain.features import build_default_feature_schema
 from taac2026.infrastructure.io.default_data_pipeline import load_dataloaders
-from taac2026.infrastructure.nn.embedding import TorchRecEmbeddingBagAdapter
 from taac2026.infrastructure.nn.quantization import quantize_model_for_inference
 from tests.support import TinyExperimentModel
-
-
-SPARSE_TABLE_NAMES = (
-    "user_tokens",
-    "context_tokens",
-    "candidate_tokens",
-    "candidate_post_tokens",
-    "candidate_author_tokens",
-)
 
 
 def _estimate_state_dict_memory_mb(model: nn.Module) -> float:
@@ -26,31 +15,6 @@ def _estimate_state_dict_memory_mb(model: nn.Module) -> float:
         if torch.is_tensor(value):
             total_bytes += value.numel() * value.element_size()
     return float(total_bytes) / (1024.0 * 1024.0)
-
-
-class TinyTorchRecInferenceModel(nn.Module):
-    def __init__(self, model_config: ModelConfig, benchmark_workspace) -> None:
-        super().__init__()
-        feature_schema = build_default_feature_schema(
-            benchmark_workspace.data_config,
-            model_config,
-        )
-        self.embedding = TorchRecEmbeddingBagAdapter(
-            feature_schema=feature_schema,
-            table_names=SPARSE_TABLE_NAMES,
-        )
-        self.output = nn.Sequential(
-            nn.Linear(self.embedding.output_dim + benchmark_workspace.data_config.dense_feature_dim, model_config.hidden_dim),
-            nn.SiLU(),
-            nn.Linear(model_config.hidden_dim, 1),
-        )
-
-    def forward(self, batch) -> torch.Tensor:
-        if batch.sparse_features is None:
-            raise RuntimeError("Benchmark batch is missing sparse_features")
-        pooled = self.embedding(batch.sparse_features)
-        fused = torch.cat([pooled, batch.dense_features], dim=-1)
-        return self.output(fused).squeeze(-1)
 
 
 def test_inference_latency_baseline(benchmark, benchmark_device, benchmark_workspace, cuda_timer, performance_recorder) -> None:
@@ -94,9 +58,13 @@ def test_inference_latency_baseline(benchmark, benchmark_device, benchmark_works
     performance_recorder("inference_latency", stats)
 
 
-def test_inference_latency_int8_quantized_torchrec(benchmark, benchmark_workspace, cuda_timer, performance_recorder) -> None:
-    model_config = ModelConfig(name="tiny_torchrec_benchmark", **benchmark_workspace.model_kwargs)
-    model = TinyTorchRecInferenceModel(model_config, benchmark_workspace)
+def test_inference_latency_int8_quantized_baseline(benchmark, benchmark_workspace, cuda_timer, performance_recorder) -> None:
+    model_config = ModelConfig(name="tiny_int8_benchmark", **benchmark_workspace.model_kwargs)
+    model = TinyExperimentModel(
+        benchmark_workspace.data_config,
+        model_config,
+        benchmark_workspace.data_config.dense_feature_dim,
+    )
     model.eval()
 
     train_loader, _, _ = load_dataloaders(
@@ -119,7 +87,7 @@ def test_inference_latency_int8_quantized_torchrec(benchmark, benchmark_workspac
         "component": "quantization",
         "phase": "phase-6",
         "label": "phase-6",
-        "model": "tiny_torchrec_int8",
+        "model": "tiny_baseline_int8",
         "metric": "latency",
     })
     benchmark(run)
@@ -130,7 +98,7 @@ def test_inference_latency_int8_quantized_torchrec(benchmark, benchmark_workspac
         "component": "quantization",
         "phase": "phase-6",
         "label": "phase-6",
-        "model": "tiny_torchrec_int8",
+        "model": "tiny_baseline_int8",
         "throughput": float(batch.batch_size) / max(stats["median_ms"] / 1e3, 1e-9),
         "memory_mb": _estimate_state_dict_memory_mb(quantized_model),
     })

--- a/tests/test_embedding_collection.py
+++ b/tests/test_embedding_collection.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 import torch
 from torch import nn
 
@@ -77,17 +78,8 @@ def test_embedding_collection_model_prefers_sparse_features() -> None:
     assert actual.shape == batch.labels.shape
 
 
-def test_quantized_embedding_collection_model_runs_with_batch_input() -> None:
+def test_quantized_embedding_collection_model_rejects_int8_quantization() -> None:
     model = TinyEmbeddingCollectionModel().eval()
-    batch = _build_batch()
 
-    quantized_model, summary = quantize_model_for_inference(model, "int8")
-
-    assert summary["active"] is True
-    assert summary["quantizable_linear_layers"] > 0
-    assert summary["quantized_embedding_collections"] > 0
-    with torch.inference_mode():
-        output = quantized_model(batch)
-
-    assert output.shape == batch.labels.shape
-    assert torch.isfinite(output).all().item()
+    with pytest.raises(ValueError, match="does not support TorchRec EmbeddingBagCollection modules"):
+        quantize_model_for_inference(model, "int8")

--- a/tests/test_evaluate_cli.py
+++ b/tests/test_evaluate_cli.py
@@ -5,12 +5,16 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from torch import nn
 
 from config.baseline.data import DENSE_FEATURE_DIM, load_dataloaders
-from taac2026.application.evaluation.cli import parse_args
+from taac2026.application.evaluation.cli import _build_single_summary_rows, _format_quantization_summary, parse_args
+from taac2026.application.evaluation.inference import normalize_inference_export_mode
 from taac2026.application.evaluation.service import _sort_records, evaluate_checkpoint
 from taac2026.domain.config import ModelConfig
+from taac2026.domain.features import FeatureSchema, FeatureTableSpec
 from taac2026.infrastructure.experiments.loader import load_experiment_package
+from taac2026.infrastructure.nn.embedding import TorchRecEmbeddingBagAdapter
 from tests.support import TestWorkspace, TinyExperimentModel, create_test_workspace
 
 
@@ -141,7 +145,71 @@ def test_evaluate_checkpoint_supports_int8_quantized_inference(test_workspace: T
     assert payload["quantization"]["active"] is True
     assert payload["quantization"]["mode"] == "int8"
     assert payload["quantization"]["quantized_linear_layers"] > 0
+    assert payload["quantization"]["reason"] == "dynamic int8 inference quantized nn.Linear modules via torchao on cpu"
+    assert "requested_mode" not in payload["quantization"]
+    assert "quantizable_linear_layers" not in payload["quantization"]
+    assert "quantizable_embedding_collections" not in payload["quantization"]
+    assert "quantized_embedding_collections" not in payload["quantization"]
+    assert "blocked_embedding_collections" not in payload["quantization"]
+    assert "blockers" not in payload["quantization"]
     assert payload["quantization"]["runtime_overrides"]["forced_device"] == "cpu"
+
+
+def test_format_quantization_summary_reports_linear_counts() -> None:
+    actual = _format_quantization_summary(
+        {
+            "mode": "int8",
+            "quantized_linear_layers": 2,
+        }
+    )
+
+    assert actual == "int8 | linear=2"
+
+
+def test_format_quantization_summary_marks_inactive_int8() -> None:
+    actual = _format_quantization_summary(
+        {
+            "mode": "int8",
+            "active": False,
+            "quantized_linear_layers": 0,
+            "reason": "model has no nn.Linear modules eligible for dynamic int8 quantization",
+        }
+    )
+
+    assert actual == "int8 | inactive"
+
+
+def test_build_single_summary_rows_includes_quantization_reason_only() -> None:
+    report = {
+        "experiment": "baseline",
+        "experiment_path": "config/baseline",
+        "checkpoint_path": "outputs/best.pt",
+        "device": "cpu",
+        "quantization": {
+            "mode": "int8",
+            "quantized_linear_layers": 3,
+            "reason": "dynamic int8 inference quantized nn.Linear modules via torchao on cpu",
+        },
+        "export": {"mode": "none", "artifact_path": None},
+        "loss": 0.125,
+        "metrics": {"auc": 0.75, "pr_auc": 0.5},
+        "mean_latency_ms_per_sample": 0.25,
+        "p95_latency_ms_per_sample": 0.4,
+    }
+
+    rows = dict(_build_single_summary_rows(report))
+
+    assert rows["quantization"] == "int8 | linear=3"
+    assert rows["quantization_reason"] == report["quantization"]["reason"]
+    assert "quantization_blockers" not in rows
+
+
+def test_normalize_inference_export_mode_rejects_legacy_aliases() -> None:
+    assert normalize_inference_export_mode(None) == "none"
+    with pytest.raises(ValueError, match="Unsupported export mode"):
+        normalize_inference_export_mode("export")
+    with pytest.raises(ValueError, match="Unsupported export mode"):
+        normalize_inference_export_mode("pt2")
 
 
 def test_evaluate_checkpoint_can_export_model_for_inference(test_workspace: TestWorkspace) -> None:
@@ -196,6 +264,52 @@ def test_evaluate_checkpoint_rejects_quantized_export_combination(test_workspace
             output_path=test_workspace.root / "evaluation_export_int8.json",
             quantization_mode="int8",
             export_mode="torch-export",
+        )
+
+
+def test_evaluate_checkpoint_rejects_int8_for_torchrec_embedding_collection_model(
+    test_workspace: TestWorkspace,
+) -> None:
+    experiment_path = test_workspace.write_experiment_package()
+    experiment = load_experiment_package(experiment_path)
+
+    feature_schema = FeatureSchema(
+        tables=(
+            FeatureTableSpec(name="user_tokens", family="user", num_embeddings=64, embedding_dim=4),
+            FeatureTableSpec(name="context_tokens", family="context", num_embeddings=64, embedding_dim=4),
+            FeatureTableSpec(name="candidate_tokens", family="candidate", num_embeddings=64, embedding_dim=4),
+        ),
+        dense_dim=DENSE_FEATURE_DIM,
+    )
+
+    class _TorchRecEvaluationModel(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.embedding = TorchRecEmbeddingBagAdapter(
+                feature_schema,
+                table_names=("user_tokens", "context_tokens", "candidate_tokens"),
+            )
+            self.output = nn.Linear(self.embedding.output_dim + DENSE_FEATURE_DIM, 1)
+
+        def forward(self, batch) -> torch.Tensor:
+            if batch.sparse_features is None:
+                raise RuntimeError("Batch is missing sparse_features")
+            pooled = self.embedding(batch.sparse_features)
+            fused = torch.cat([pooled, batch.dense_features], dim=-1)
+            return self.output(fused).squeeze(-1)
+
+    experiment.build_model_component = lambda data_config, model_config, dense_dim: _TorchRecEvaluationModel()
+    model = experiment.build_model_component(experiment.data, experiment.model, DENSE_FEATURE_DIM)
+    checkpoint_path = test_workspace.root / "torchrec_ebc_int8.pt"
+    torch.save({"model_state_dict": model.state_dict()}, checkpoint_path)
+
+    with pytest.raises(ValueError, match="does not support TorchRec EmbeddingBagCollection modules"):
+        evaluate_checkpoint(
+            experiment_path=experiment_path,
+            checkpoint_path=checkpoint_path,
+            output_path=test_workspace.root / "evaluation_torchrec_ebc_int8.json",
+            experiment=experiment,
+            quantization_mode="int8",
         )
 
 

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -364,6 +364,23 @@ class TestTorchCompileGpu:
         assert torch.isfinite(logits).all()
 
 
+class TestTorchaoGpuExtensions:
+    def test_torchao_native_extensions_match_cuda_toolchain(self):
+        import torchao
+
+        assert "+cu128" in getattr(torchao, "__version__", "")
+
+        extension_paths = sorted(Path(torchao.__file__).resolve().parent.glob("_C*.so"))
+        assert extension_paths, "torchao CUDA wheel did not expose native extensions"
+
+        loaded: list[str] = []
+        for extension_path in extension_paths:
+            torch.ops.load_library(str(extension_path))
+            loaded.append(extension_path.name)
+
+        assert loaded
+
+
 # ---------------------------------------------------------------------------
 # 6. GPU memory management
 # ---------------------------------------------------------------------------

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -1,20 +1,22 @@
 from __future__ import annotations
 
+import pytest
 import torch
 from torch import nn
 
 from taac2026.domain.features import FeatureSchema, FeatureTableSpec
-from taac2026.infrastructure.io.sparse_collate import keyed_jagged_from_masked_batches
 from taac2026.infrastructure.nn.embedding import TorchRecEmbeddingBagAdapter
 from taac2026.infrastructure.nn.quantization import normalize_quantization_mode, quantize_model_for_inference
 from taac2026.infrastructure.nn.triton_attention import reference_attention, triton_attention
 from taac2026.infrastructure.nn.triton_ffn import reference_ffn_activation, triton_ffn_activation
 
 
-def test_normalize_quantization_mode_accepts_aliases() -> None:
+def test_normalize_quantization_mode_rejects_legacy_aliases() -> None:
     assert normalize_quantization_mode(None) == "none"
-    assert normalize_quantization_mode("off") == "none"
-    assert normalize_quantization_mode("linear-int8") == "int8"
+    with pytest.raises(ValueError, match="Unsupported quantization mode"):
+        normalize_quantization_mode("off")
+    with pytest.raises(ValueError, match="Unsupported quantization mode"):
+        normalize_quantization_mode("linear-int8")
 
 
 def test_quantize_model_for_inference_quantizes_linear_layers() -> None:
@@ -35,20 +37,27 @@ def test_quantize_model_for_inference_quantizes_linear_layers() -> None:
     assert output.shape == (2, 4)
 
 
-def test_quantize_model_for_inference_quantizes_torchrec_embedding_bag_collections() -> None:
+def test_quantize_model_for_inference_keeps_original_model_unmodified() -> None:
+    model = nn.Sequential(
+        nn.Linear(8, 16),
+        nn.SiLU(),
+        nn.Linear(16, 4),
+    )
+
+    quantized_model, summary = quantize_model_for_inference(model, "int8")
+
+    assert summary["active"] is True
+    assert quantized_model is not model
+    assert isinstance(model[0].weight, nn.Parameter)
+    assert type(quantized_model[0].weight).__name__ == "Int8Tensor"
+
+
+def test_quantize_model_for_inference_rejects_torchrec_embedding_bag_collections() -> None:
     feature_schema = FeatureSchema(
         tables=(
             FeatureTableSpec(name="user_tokens", family="user", num_embeddings=64, embedding_dim=4),
         ),
         dense_dim=0,
-    )
-    features = keyed_jagged_from_masked_batches(
-        {
-            "user_tokens": (
-                torch.tensor([[1, 2, 0], [3, 0, 0]], dtype=torch.long),
-                torch.tensor([[True, True, False], [True, False, False]], dtype=torch.bool),
-            ),
-        }
     )
 
     class TinyTorchRecModel(nn.Module):
@@ -63,12 +72,8 @@ def test_quantize_model_for_inference_quantizes_torchrec_embedding_bag_collectio
 
     model = TinyTorchRecModel()
 
-    quantized_model, summary = quantize_model_for_inference(model, "int8")
-
-    assert summary["active"] is True
-    assert summary["quantized_embedding_collections"] > 0
-    output = quantized_model(features)
-    assert output.shape == (2, 2)
+    with pytest.raises(ValueError, match="does not support TorchRec EmbeddingBagCollection modules"):
+        quantize_model_for_inference(model, "int8")
 
 
 def test_reference_attention_supports_fp8_precision_mode() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1792,6 +1792,7 @@ dependencies = [
     { name = "pytest-benchmark" },
     { name = "rich" },
     { name = "torch", marker = "sys_platform == 'linux'" },
+    { name = "torchao", marker = "sys_platform == 'linux'" },
     { name = "torchrec", marker = "sys_platform == 'linux'" },
     { name = "triton", marker = "sys_platform == 'linux'" },
 ]
@@ -1815,6 +1816,7 @@ requires-dist = [
     { name = "pytest-benchmark", specifier = ">=5.1" },
     { name = "rich", specifier = ">=13.9" },
     { name = "torch", marker = "sys_platform == 'linux'", specifier = ">=2.6", index = "https://download.pytorch.org/whl/cu128" },
+    { name = "torchao", marker = "sys_platform == 'linux'", specifier = ">=0.17", index = "https://download.pytorch.org/whl/cu128" },
     { name = "torchrec", marker = "sys_platform == 'linux'", specifier = ">=1.0" },
     { name = "transformer-engine", extras = ["pytorch"], marker = "sys_platform == 'linux' and extra == 'te'", specifier = ">=2.13" },
     { name = "triton", marker = "sys_platform == 'linux'", specifier = ">=3.2" },
@@ -1870,6 +1872,14 @@ wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl" },
     { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl" },
     { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl" },
+]
+
+[[package]]
+name = "torchao"
+version = "0.17.0+cu128"
+source = { registry = "https://download.pytorch.org/whl/cu128" }
+wheels = [
+    { url = "https://download.pytorch.org/whl/cu128/torchao-0.17.0%2Bcu128-cp310-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ceea15b9b14d1fc20029a89dddcc4dd2d9aeef9a749c8c9f8437ffb81aa443aa" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- migrate evaluation int8 quantization from deprecated torch.ao eager APIs to torchao for nn.Linear on CPU
- remove legacy quantization and export aliases, make TorchRec EmbeddingBagCollection explicitly unsupported for int8, and keep quantization isolated to a copied model
- update evaluation CLI summaries, GPU environment verification, benchmarks, tests, and docs to match the new contract

## Validation
- uv run pytest tests/test_quantization.py tests/test_embedding_collection.py tests/test_evaluate_cli.py tests/benchmarks/bench_inference_latency.py -q
- uv run pytest tests/test_gpu.py -q -k torchao_native_extensions_match_cuda_toolchain
- uv run pytest tests/test_quantization.py tests/test_embedding_collection.py tests/test_evaluate_cli.py tests/benchmarks/bench_inference_latency.py tests/test_gpu.py -q -k 'not gpu and not test_torchao_native_extensions_match_cuda_toolchain'
- uv run python scripts/verify_gpu_env.py --json
- uv run --no-project --isolated --with zensical zensical build --clean

Closes #36.