### PR TITLE
refactor: 修改了数据集选择和加载方式，并更新了相应文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,22 @@ uv run taac-search --experiment config/baseline --trials 20
 uv run taac-evaluate single --experiment config/baseline
 ```
 
+训练/评估默认会使用 HuggingFace 数据集名 `TAAC2026/data_sample_1000`。
+你可以随时覆盖为本地或自定义数据源：
+
+```bash
+# 覆盖为本地 parquet
+uv run taac-train --experiment config/baseline --dataset-path /path/to/train.parquet
+
+# 覆盖为本地目录（包含 parquet）
+uv run taac-train --experiment config/baseline --dataset-path /path/to/dataset_dir
+
+# 覆盖为自定义 Hub 数据集名
+uv run taac-train --experiment config/baseline --dataset-path some_owner/some_dataset
+```
+
+若目标 Hub 数据集尚未缓存，`datasets` 会自动下载并写入本地缓存。
+
 仓库在 `pyproject.toml` 里固定了 `uv` 的 canonical 默认索引，用来保证 `uv.lock` 在本机和 CI 间保持一致。
 如果你的机器全局把 `uv` 换到国内镜像，普通 `uv sync --locked` 仍会按项目配置工作；不要再额外传 `--default-index` 或 `--index-url` 指向镜像，否则 `uv` 会判定 `uv.lock` 需要更新。
 如果只是想加速下载，优先使用系统代理、透明代理或企业缓存代理；如果你确实临时用镜像做过一次重锁，提交前请执行 `uv lock --default-index https://pypi.org/simple --python 3.13` 把锁文件归一回仓库基线。

--- a/config/baseline/__init__.py
+++ b/config/baseline/__init__.py
@@ -9,15 +9,13 @@ from taac2026.domain.features import build_default_feature_schema
 from .model import build_model_component
 
 
-ROOT = Path(__file__).resolve().parents[2]
-DEFAULT_DATASET = ROOT / "data" / "datasets--TAAC2026--data_sample_1000"
-DEFAULT_OUTPUT_DIR = ROOT / "outputs" / "config" / "baseline"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "outputs" / "config" / "baseline"
 
 
 EXPERIMENT = ExperimentSpec(
     name="baseline_reference",
     data=DataConfig(
-        dataset_path=str(DEFAULT_DATASET),
         max_seq_len=32,
         max_feature_tokens=16,
         max_event_features=4,

--- a/config/ctr_baseline/__init__.py
+++ b/config/ctr_baseline/__init__.py
@@ -9,15 +9,13 @@ from taac2026.domain.features import build_default_feature_schema
 from .model import build_model_component
 
 
-ROOT = Path(__file__).resolve().parents[2]
-DEFAULT_DATASET = ROOT / "data" / "datasets--TAAC2026--data_sample_1000"
-DEFAULT_OUTPUT_DIR = ROOT / "outputs" / "config" / "ctr_baseline"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "outputs" / "config" / "ctr_baseline"
 
 
 EXPERIMENT = ExperimentSpec(
     name="ctr_baseline_din",
     data=DataConfig(
-        dataset_path=str(DEFAULT_DATASET),
         max_seq_len=32,
         max_feature_tokens=16,
         max_event_features=4,

--- a/config/deepcontextnet/__init__.py
+++ b/config/deepcontextnet/__init__.py
@@ -9,15 +9,13 @@ from taac2026.domain.features import build_default_feature_schema
 from .model import build_model_component
 
 
-ROOT = Path(__file__).resolve().parents[2]
-DEFAULT_DATASET = ROOT / "data" / "datasets--TAAC2026--data_sample_1000"
-DEFAULT_OUTPUT_DIR = ROOT / "outputs" / "config" / "deepcontextnet"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "outputs" / "config" / "deepcontextnet"
 
 
 EXPERIMENT = ExperimentSpec(
     name="deepcontextnet",
     data=DataConfig(
-        dataset_path=str(DEFAULT_DATASET),
         max_seq_len=32,
         max_feature_tokens=16,
         max_event_features=4,

--- a/config/grok/__init__.py
+++ b/config/grok/__init__.py
@@ -9,15 +9,13 @@ from taac2026.domain.features import build_default_feature_schema
 from .model import build_model_component
 
 
-ROOT = Path(__file__).resolve().parents[2]
-DEFAULT_DATASET = ROOT / "data" / "datasets--TAAC2026--data_sample_1000"
-DEFAULT_OUTPUT_DIR = ROOT / "outputs" / "config" / "grok"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "outputs" / "config" / "grok"
 
 
 EXPERIMENT = ExperimentSpec(
     name="grok",
     data=DataConfig(
-        dataset_path=str(DEFAULT_DATASET),
         max_seq_len=32,
         max_feature_tokens=16,
         max_event_features=4,

--- a/config/hyformer/__init__.py
+++ b/config/hyformer/__init__.py
@@ -9,15 +9,13 @@ from taac2026.domain.features import build_default_feature_schema
 from .model import build_model_component
 
 
-ROOT = Path(__file__).resolve().parents[2]
-DEFAULT_DATASET = ROOT / "data" / "datasets--TAAC2026--data_sample_1000"
-DEFAULT_OUTPUT_DIR = ROOT / "outputs" / "config" / "hyformer"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "outputs" / "config" / "hyformer"
 
 
 EXPERIMENT = ExperimentSpec(
 	name="hyformer",
 	data=DataConfig(
-		dataset_path=str(DEFAULT_DATASET),
 		max_seq_len=32,
 		max_feature_tokens=16,
 		max_event_features=4,

--- a/config/interformer/__init__.py
+++ b/config/interformer/__init__.py
@@ -9,15 +9,13 @@ from taac2026.domain.features import build_default_feature_schema
 from .model import build_model_component
 
 
-ROOT = Path(__file__).resolve().parents[2]
-DEFAULT_DATASET = ROOT / "data" / "datasets--TAAC2026--data_sample_1000"
-DEFAULT_OUTPUT_DIR = ROOT / "outputs" / "config" / "interformer"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "outputs" / "config" / "interformer"
 
 
 EXPERIMENT = ExperimentSpec(
 	name="interformer",
 	data=DataConfig(
-		dataset_path=str(DEFAULT_DATASET),
 		max_seq_len=32,
 		max_feature_tokens=16,
 		max_event_features=4,

--- a/config/onetrans/__init__.py
+++ b/config/onetrans/__init__.py
@@ -9,15 +9,13 @@ from taac2026.domain.features import build_default_feature_schema
 from .model import build_model_component
 
 
-ROOT = Path(__file__).resolve().parents[2]
-DEFAULT_DATASET = ROOT / "data" / "datasets--TAAC2026--data_sample_1000"
-DEFAULT_OUTPUT_DIR = ROOT / "outputs" / "config" / "onetrans"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "outputs" / "config" / "onetrans"
 
 
 EXPERIMENT = ExperimentSpec(
 	name="onetrans",
 	data=DataConfig(
-		dataset_path=str(DEFAULT_DATASET),
 		max_seq_len=32,
 		max_feature_tokens=16,
 		max_event_features=4,

--- a/config/oo/__init__.py
+++ b/config/oo/__init__.py
@@ -9,15 +9,13 @@ from taac2026.domain.features import build_default_feature_schema
 from .model import build_model_component
 
 
-ROOT = Path(__file__).resolve().parents[2]
-DEFAULT_DATASET = ROOT / "data" / "datasets--TAAC2026--data_sample_1000"
-DEFAULT_OUTPUT_DIR = ROOT / "outputs" / "config" / "oo"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "outputs" / "config" / "oo"
 
 
 EXPERIMENT = ExperimentSpec(
 	name="oo",
 	data=DataConfig(
-		dataset_path=str(DEFAULT_DATASET),
 		max_seq_len=32,
 		max_feature_tokens=16,
 		max_event_features=4,

--- a/config/unirec/__init__.py
+++ b/config/unirec/__init__.py
@@ -10,15 +10,13 @@ from .model import build_model_component
 from .utils import build_optimizer_component
 
 
-ROOT = Path(__file__).resolve().parents[2]
-DEFAULT_DATASET = ROOT / "data" / "datasets--TAAC2026--data_sample_1000"
-DEFAULT_OUTPUT_DIR = ROOT / "outputs" / "config" / "unirec"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "outputs" / "config" / "unirec"
 
 
 EXPERIMENT = ExperimentSpec(
 	name="unirec",
 	data=DataConfig(
-		dataset_path=str(DEFAULT_DATASET),
 		max_seq_len=32,
 		max_feature_tokens=16,
 		max_event_features=4,

--- a/config/uniscaleformer/__init__.py
+++ b/config/uniscaleformer/__init__.py
@@ -9,15 +9,13 @@ from taac2026.domain.features import build_default_feature_schema
 from .model import build_model_component
 
 
-ROOT = Path(__file__).resolve().parents[2]
-DEFAULT_DATASET = ROOT / "data" / "datasets--TAAC2026--data_sample_1000"
-DEFAULT_OUTPUT_DIR = ROOT / "outputs" / "config" / "uniscaleformer"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "outputs" / "config" / "uniscaleformer"
 
 
 EXPERIMENT = ExperimentSpec(
 	name="uniscaleformer",
 	data=DataConfig(
-		dataset_path=str(DEFAULT_DATASET),
 		max_seq_len=32,
 		max_feature_tokens=16,
 		max_event_features=4,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -44,22 +44,6 @@ bash .devcontainer/post-create.sh
 
 该脚本会安装 Python 3.13、执行 `uv sync --locked`，并运行 GPU / TorchRec 自检脚本。
 
-## 下载样例数据
-
-实验包默认使用 HuggingFace 上的样例数据集 [`TAAC2026/data_sample_1000`](https://huggingface.co/datasets/TAAC2026/data_sample_1000)。框架会自动从本地 HuggingFace 缓存中解析数据路径。
-
-如果 `data/datasets--TAAC2026--data_sample_1000/` 还不存在，第一次运行训练/评估命令时也会自动回退到该 HF 数据集名，并把下载内容写入父目录 `data/` 作为缓存根。
-
-```bash
-# 下载数据到仓库根下的 data/ 目录（作为 HF 缓存根）
-uv run python -c "
-from datasets import load_dataset
-load_dataset('TAAC2026/data_sample_1000', cache_dir='data')
-"
-```
-
-下载完成后，实验包会自动在 `data/datasets--TAAC2026--data_sample_1000/` 下解析 parquet 文件，优先使用 `refs/main` 指向的快照，无需手动指定版本哈希。
-
 ## 训练第一个模型
 
 ```bash
@@ -89,6 +73,31 @@ uv run taac-package-train --experiment config/baseline
 ```
 
 默认产物会写到 `outputs/training_bundles/baseline-train-bundle.zip`。
+
+## 数据集选择
+
+实验包默认使用 HuggingFace 上的样例数据集 [`TAAC2026/data_sample_1000`](https://huggingface.co/datasets/TAAC2026/data_sample_1000)。
+
+默认行为如下：
+
+- 不传 `--dataset-path`：直接按数据集名 `TAAC2026/data_sample_1000` 加载
+- 传本地路径：支持 parquet 文件路径或包含 parquet 的目录路径
+- 传自定义 Hub 名称：按你给的 `<owner>/<repo>` 直接加载
+
+当目标 Hub 数据不在本地缓存时，`datasets` 会自动下载并写入缓存。
+
+你也可以显式指定数据路径覆盖默认值：
+
+```bash
+# 本地 parquet
+uv run taac-train --experiment config/baseline --dataset-path /path/to/train.parquet
+
+# 本地目录（包含 parquet）
+uv run taac-train --experiment config/baseline --dataset-path /path/to/dataset_dir
+
+# 自定义 Hub 数据集名
+uv run taac-train --experiment config/baseline --dataset-path some_owner/some_dataset
+```
 
 ## 评估
 

--- a/docs/guide/contributing.md
+++ b/docs/guide/contributing.md
@@ -41,14 +41,12 @@ from taac2026.domain.features import build_default_feature_schema
 
 from .model import build_model_component
 
-ROOT = Path(__file__).resolve().parents[2]
-DEFAULT_DATASET = ROOT / "data" / "datasets--TAAC2026--data_sample_1000"
-DEFAULT_OUTPUT_DIR = ROOT / "outputs" / "config" / "my_experiment"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "outputs" / "config" / "my_experiment"
 
 EXPERIMENT = ExperimentSpec(
     name="my_experiment",
     data=DataConfig(
-        dataset_path=str(DEFAULT_DATASET),
         max_seq_len=32,
         max_feature_tokens=16,
         max_event_features=4,
@@ -198,12 +196,13 @@ uv run taac-evaluate single --experiment config/my_experiment
 
 ## 数据与 schema 约定
 
-默认数据集路径仍指向 HuggingFace 缓存结构：
+默认数据集标识为 HuggingFace 数据集名：
 
 ```
-data/datasets--TAAC2026--data_sample_1000/
+TAAC2026/data_sample_1000
 ```
 
-框架会优先解析本地缓存并读取 `refs/main` 对应快照；如果本地缓存缺失，默认数据管道会按数据集名回退下载。
+你仍然可以在实验包里显式覆盖 `dataset_path`（本地 parquet、本地目录或自定义 Hub 数据集名）。
+默认值在缓存缺失时会自动触发下载并写入本地 HuggingFace 缓存。
 
 `feature_schema` 建议通过 `build_default_feature_schema()` 派生，再根据实验需求做局部调整，而不是从零复制整套表定义。

--- a/src/taac2026/domain/config.py
+++ b/src/taac2026/domain/config.py
@@ -10,7 +10,7 @@ DEFAULT_MAX_END_TO_END_INFERENCE_SECONDS = 180.0
 
 @dataclass(slots=True)
 class DataConfig:
-    dataset_path: str
+    dataset_path: str = "TAAC2026/data_sample_1000"
     max_seq_len: int = 64
     max_feature_tokens: int = 24
     max_event_features: int = 4

--- a/tests/test_experiment_packages.py
+++ b/tests/test_experiment_packages.py
@@ -274,7 +274,7 @@ def test_experiment_package_directory_path_loads_namespace_relative_imports(expe
         "config.oo",
     ],
 )
-def test_experiment_package_default_dataset_points_to_hf_cache_root(module_path: str) -> None:
+def test_experiment_package_default_dataset_is_hf_hub_dataset_name(module_path: str) -> None:
     experiment = importlib.import_module(module_path).EXPERIMENT
     assert experiment.data.dataset_path == "TAAC2026/data_sample_1000"
 

--- a/tests/test_experiment_packages.py
+++ b/tests/test_experiment_packages.py
@@ -276,10 +276,7 @@ def test_experiment_package_directory_path_loads_namespace_relative_imports(expe
 )
 def test_experiment_package_default_dataset_points_to_hf_cache_root(module_path: str) -> None:
     experiment = importlib.import_module(module_path).EXPERIMENT
-    dataset_path = Path(experiment.data.dataset_path)
-
-    assert dataset_path.name == "datasets--TAAC2026--data_sample_1000"
-    assert "snapshots" not in dataset_path.parts
+    assert experiment.data.dataset_path == "TAAC2026/data_sample_1000"
 
 
 def test_resolve_parquet_dataset_path_prefers_hf_main_ref(tmp_path: Path) -> None:


### PR DESCRIPTION
📝 **修改描述**
本次重构旨在移除 config 包中硬编码的数据集本地路径，转而默认使用 HuggingFace Hub 标识符进行数据集加载。这一改动提高了项目的可移植性，使得其他开发者无需手动配置本地数据路径即可运行项目。

主要变更包括：

**移除硬编码路径**：从 config 模块中移除了对本地绝对/相对路径的依赖。
**集成 HF Hub加载**：更新数据集加载逻辑，默认通过 datasets 库使用 HuggingFace Hub 标识符（如 dataset_name）拉取数据。
**配置灵活性**：保留了通过环境变量或配置文件覆盖默认数据集标识符的能力（如果有的话，可以加上这条）。
**文档更新**：同步更新了 README.md 及相关开发文档，说明新的数据集配置方式及所需的环境准备。

🔗 **关联 Issue**
refactor: 移除 config 包硬编码数据集路径，默认使用 HuggingFace Hub 标识符 #29

🧪 测试方式
在干净的环境中（无本地缓存或特定路径配置）测试数据集能否通过 HF Hub 正常下载和加载。
验证现有模型训练/评估流程是否因数据加载方式的改变而受到影响。
检查文档中的示例命令是否可执行。