### PR TITLE
feat: add AMP and torch.compile support to shared PCVR runtime

### DIFF
--- a/src/taac2026/application/evaluation/cli.py
+++ b/src/taac2026/application/evaluation/cli.py
@@ -11,10 +11,17 @@ import torch
 
 from taac2026.domain.config import EvalRequest, InferRequest, default_run_dir
 from taac2026.infrastructure.experiments.loader import load_experiment_package
+from taac2026.infrastructure.training.runtime import AMP_DTYPE_CHOICES
 
 
 def _default_device() -> str:
     return "cuda" if torch.cuda.is_available() else "cpu"
+
+
+def _add_runtime_execution_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--amp", action=argparse.BooleanOptionalAction, default=None)
+    parser.add_argument("--amp-dtype", default=None, choices=AMP_DTYPE_CHOICES)
+    parser.add_argument("--compile", action=argparse.BooleanOptionalAction, default=None)
 
 
 def parse_eval_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -32,6 +39,7 @@ def parse_eval_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     single.add_argument("--batch-size", type=int, default=256)
     single.add_argument("--num-workers", type=int, default=0)
     single.add_argument("--device", default=_default_device())
+    _add_runtime_execution_args(single)
     single.add_argument("--json", action="store_true")
 
     infer = subparsers.add_parser("infer", help="write platform predictions.json")
@@ -43,6 +51,7 @@ def parse_eval_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     infer.add_argument("--batch-size", type=int, default=256)
     infer.add_argument("--num-workers", type=int, default=0)
     infer.add_argument("--device", default=_default_device())
+    _add_runtime_execution_args(infer)
     infer.add_argument("--json", action="store_true")
     return parser.parse_args(argv)
 
@@ -63,6 +72,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             batch_size=args.batch_size,
             num_workers=args.num_workers,
             device=args.device,
+            amp=args.amp,
+            amp_dtype=args.amp_dtype,
+            compile=args.compile,
         )
         payload = experiment.evaluate(request)
     else:
@@ -75,6 +87,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             batch_size=args.batch_size,
             num_workers=args.num_workers,
             device=args.device,
+            amp=args.amp,
+            amp_dtype=args.amp_dtype,
+            compile=args.compile,
         )
         payload = experiment.infer(request)
 

--- a/src/taac2026/application/evaluation/infer.py
+++ b/src/taac2026/application/evaluation/infer.py
@@ -8,6 +8,18 @@ from pathlib import Path
 from taac2026.application.evaluation.cli import main as evaluation_main
 
 
+def _read_optional_bool_env(name: str) -> bool | None:
+    value = os.environ.get(name)
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise RuntimeError(f"{name} must be one of 1/0/true/false/yes/no/on/off")
+
+
 def main() -> None:
     dataset_path = os.environ.get("EVAL_DATA_PATH")
     result_path = os.environ.get("EVAL_RESULT_PATH")
@@ -16,6 +28,9 @@ def main() -> None:
     experiment_path = os.environ.get("TAAC_EXPERIMENT")
     infer_batch_size = os.environ.get("TAAC_INFER_BATCH_SIZE")
     infer_num_workers = os.environ.get("TAAC_INFER_NUM_WORKERS")
+    infer_amp = _read_optional_bool_env("TAAC_INFER_AMP")
+    infer_amp_dtype = os.environ.get("TAAC_INFER_AMP_DTYPE")
+    infer_compile = _read_optional_bool_env("TAAC_INFER_COMPILE")
     if not dataset_path:
         raise RuntimeError("EVAL_DATA_PATH is required")
     if not result_path:
@@ -39,6 +54,16 @@ def main() -> None:
         argv.extend(["--batch-size", infer_batch_size])
     if infer_num_workers:
         argv.extend(["--num-workers", infer_num_workers])
+    if infer_amp is True:
+        argv.append("--amp")
+    elif infer_amp is False:
+        argv.append("--no-amp")
+    if infer_amp_dtype:
+        argv.extend(["--amp-dtype", infer_amp_dtype])
+    if infer_compile is True:
+        argv.append("--compile")
+    elif infer_compile is False:
+        argv.append("--no-compile")
     evaluation_main(argv)
 
 

--- a/src/taac2026/domain/config.py
+++ b/src/taac2026/domain/config.py
@@ -27,6 +27,9 @@ class EvalRequest:
     batch_size: int = 256
     num_workers: int = 0
     device: str = "cpu"
+    amp: bool | None = None
+    amp_dtype: str | None = None
+    compile: bool | None = None
     is_training_data: bool = True
     extra_args: tuple[str, ...] = ()
 
@@ -41,6 +44,9 @@ class InferRequest:
     batch_size: int = 256
     num_workers: int = 0
     device: str = "cpu"
+    amp: bool | None = None
+    amp_dtype: str | None = None
+    compile: bool | None = None
 
 
 def experiment_slug(value: str) -> str:

--- a/src/taac2026/infrastructure/pcvr/experiment.py
+++ b/src/taac2026/infrastructure/pcvr/experiment.py
@@ -30,6 +30,7 @@ from taac2026.infrastructure.pcvr.protocol import (
     resolve_schema_path,
 )
 from taac2026.infrastructure.pcvr.training import train_pcvr_model
+from taac2026.infrastructure.training.runtime import RuntimeExecutionConfig, maybe_compile_callable, normalize_amp_dtype
 
 
 _PLUGIN_MODULE_NAMES = ("utils", "model")
@@ -59,6 +60,20 @@ def _read_flag_value(args: tuple[str, ...], flag_names: tuple[str, ...]) -> str 
         else:
             index += 1
     return None
+
+
+def _read_bool_flag_value(
+    args: tuple[str, ...],
+    enabled_flags: tuple[str, ...],
+    disabled_flags: tuple[str, ...],
+) -> bool | None:
+    resolved: bool | None = None
+    for token in args:
+        if token in enabled_flags:
+            resolved = True
+        elif token in disabled_flags:
+            resolved = False
+    return resolved
 
 
 def _log_prediction_progress(
@@ -156,16 +171,42 @@ class PCVRExperiment:
         checkpoint = resolve_checkpoint_path(request.run_dir, request.checkpoint_path)
         output_path = request.output_path or (request.run_dir / "evaluation.json")
         predictions_path = request.predictions_path or (request.run_dir / "validation_predictions.jsonl")
+        config = self._load_train_config(checkpoint.parent)
+        effective_batch_size, batch_size_source, effective_num_workers, num_workers_source = self._resolve_prediction_runtime_settings(
+            request,
+            config,
+        )
+        runtime_execution, amp_source, amp_dtype_source, compile_source = self._resolve_prediction_runtime_execution(
+            request,
+            config,
+        )
+        logging.info(
+            "Resolved PCVR evaluation runtime: experiment=%s, checkpoint=%s, batch_size=%d (%s), num_workers=%d (%s), amp=%s (%s), amp_dtype=%s (%s), compile=%s (%s)",
+            self.name,
+            checkpoint,
+            effective_batch_size,
+            batch_size_source,
+            effective_num_workers,
+            num_workers_source,
+            runtime_execution.amp,
+            amp_source,
+            runtime_execution.normalized_amp_dtype(),
+            amp_dtype_source,
+            runtime_execution.compile,
+            compile_source,
+        )
 
         with self._module_context():
             evaluation = self._run_prediction_loop(
                 dataset_path=request.dataset_path,
                 schema_path=request.schema_path,
                 checkpoint_path=checkpoint,
-                batch_size=request.batch_size,
-                num_workers=request.num_workers,
+                batch_size=effective_batch_size,
+                num_workers=effective_num_workers,
                 device=request.device,
                 is_training_data=request.is_training_data,
+                config=config,
+                runtime_execution=runtime_execution,
             )
 
         labels = np.asarray(evaluation["labels"], dtype=np.float64)
@@ -198,18 +239,28 @@ class PCVRExperiment:
         if checkpoint is None:
             checkpoint = resolve_checkpoint_path(Path.cwd())
         config = self._load_train_config(checkpoint.parent)
-        effective_batch_size, batch_size_source, effective_num_workers, num_workers_source = self._resolve_infer_runtime_settings(
+        effective_batch_size, batch_size_source, effective_num_workers, num_workers_source = self._resolve_prediction_runtime_settings(
+            request,
+            config,
+        )
+        runtime_execution, amp_source, amp_dtype_source, compile_source = self._resolve_prediction_runtime_execution(
             request,
             config,
         )
         logging.info(
-            "Resolved PCVR inference runtime: experiment=%s, checkpoint=%s, batch_size=%d (%s), num_workers=%d (%s)",
+            "Resolved PCVR inference runtime: experiment=%s, checkpoint=%s, batch_size=%d (%s), num_workers=%d (%s), amp=%s (%s), amp_dtype=%s (%s), compile=%s (%s)",
             self.name,
             checkpoint,
             effective_batch_size,
             batch_size_source,
             effective_num_workers,
             num_workers_source,
+            runtime_execution.amp,
+            amp_source,
+            runtime_execution.normalized_amp_dtype(),
+            amp_dtype_source,
+            runtime_execution.compile,
+            compile_source,
         )
 
         with self._module_context():
@@ -222,6 +273,7 @@ class PCVRExperiment:
                 device=request.device,
                 is_training_data=False,
                 config=config,
+                runtime_execution=runtime_execution,
             )
 
         prediction_map = {
@@ -257,9 +309,9 @@ class PCVRExperiment:
 
         return None, None
 
-    def _resolve_infer_runtime_settings(
+    def _resolve_prediction_runtime_settings(
         self,
-        request: InferRequest,
+        request: EvalRequest | InferRequest,
         config: dict[str, Any],
     ) -> tuple[int, str, int, str]:
         batch_size = int(request.batch_size)
@@ -290,6 +342,88 @@ class PCVRExperiment:
 
         return batch_size, batch_size_source, num_workers, num_workers_source
 
+    def _resolve_infer_runtime_settings(
+        self,
+        request: InferRequest,
+        config: dict[str, Any],
+    ) -> tuple[int, str, int, str]:
+        return self._resolve_prediction_runtime_settings(request, config)
+
+    def _configured_runtime_flag(
+        self,
+        request_value: bool | None,
+        config: dict[str, Any],
+        *,
+        config_key: str,
+        enabled_flags: tuple[str, ...],
+        disabled_flags: tuple[str, ...],
+        default: bool,
+    ) -> tuple[bool, str]:
+        if request_value is not None:
+            return bool(request_value), "request"
+
+        configured_value = config.get(config_key)
+        if isinstance(configured_value, bool):
+            return configured_value, "train_config"
+
+        default_arg_value = _read_bool_flag_value(self.default_train_args, enabled_flags, disabled_flags)
+        if default_arg_value is not None:
+            return default_arg_value, "experiment_default_train_args"
+
+        return default, "default"
+
+    def _configured_runtime_string(
+        self,
+        request_value: str | None,
+        config: dict[str, Any],
+        *,
+        config_key: str,
+        flag_names: tuple[str, ...],
+        default: str,
+    ) -> tuple[str, str]:
+        if request_value not in (None, ""):
+            return normalize_amp_dtype(request_value), "request"
+
+        configured_value = config.get(config_key)
+        if isinstance(configured_value, str) and configured_value.strip():
+            return normalize_amp_dtype(configured_value), "train_config"
+
+        default_arg_value = _read_flag_value(self.default_train_args, flag_names)
+        if default_arg_value not in (None, ""):
+            return normalize_amp_dtype(default_arg_value), "experiment_default_train_args"
+
+        return normalize_amp_dtype(default), "default"
+
+    def _resolve_prediction_runtime_execution(
+        self,
+        request: EvalRequest | InferRequest,
+        config: dict[str, Any],
+    ) -> tuple[RuntimeExecutionConfig, str, str, str]:
+        amp, amp_source = self._configured_runtime_flag(
+            getattr(request, "amp", None),
+            config,
+            config_key="amp",
+            enabled_flags=("--amp",),
+            disabled_flags=("--no-amp",),
+            default=False,
+        )
+        amp_dtype, amp_dtype_source = self._configured_runtime_string(
+            getattr(request, "amp_dtype", None),
+            config,
+            config_key="amp_dtype",
+            flag_names=("--amp_dtype", "--amp-dtype"),
+            default="bfloat16",
+        )
+        compile_enabled, compile_source = self._configured_runtime_flag(
+            getattr(request, "compile", None),
+            config,
+            config_key="compile",
+            enabled_flags=("--compile",),
+            disabled_flags=("--no-compile",),
+            default=False,
+        )
+        return RuntimeExecutionConfig(amp=amp, amp_dtype=amp_dtype, compile=compile_enabled), amp_source, amp_dtype_source, compile_source
+
     def _run_prediction_loop(
         self,
         *,
@@ -301,6 +435,7 @@ class PCVRExperiment:
         device: str,
         is_training_data: bool,
         config: dict[str, Any] | None = None,
+        runtime_execution: RuntimeExecutionConfig | None = None,
     ) -> dict[str, Any]:
         import model as model_module
 
@@ -329,16 +464,22 @@ class PCVRExperiment:
             checkpoint_dir=checkpoint_path.parent,
         )
         runtime_device = torch.device(device)
+        resolved_runtime_execution = runtime_execution or RuntimeExecutionConfig()
         model.to(runtime_device)
         state_dict = torch.load(checkpoint_path, map_location=runtime_device)
         model.load_state_dict(state_dict)
         model.eval()
+        predict_fn = maybe_compile_callable(
+            model.predict,
+            enabled=resolved_runtime_execution.compile,
+            label=f"PCVR {'evaluation' if is_training_data else 'inference'} predict",
+        )
 
         mode = "evaluation" if is_training_data else "inference"
         total_rows = int(getattr(dataset, "num_rows", 0))
         total_batches = (total_rows + batch_size - 1) // batch_size if total_rows > 0 else 0
         logging.info(
-            "PCVR %s loop starting: checkpoint=%s, rows=%d, estimated_batches=%d, batch_size=%d, num_workers=%d, device=%s",
+            "PCVR %s loop starting: checkpoint=%s, rows=%d, estimated_batches=%d, batch_size=%d, num_workers=%d, device=%s, runtime=%s",
             mode,
             checkpoint_path,
             total_rows,
@@ -346,6 +487,7 @@ class PCVRExperiment:
             batch_size,
             num_workers,
             device,
+            resolved_runtime_execution.summary(runtime_device),
         )
 
         labels: list[float] = []
@@ -359,7 +501,8 @@ class PCVRExperiment:
         with torch.no_grad():
             for batch_count, batch in enumerate(loader, start=1):
                 model_input = batch_to_model_input(batch, model_module.ModelInput, runtime_device)
-                logits, _embeddings = model.predict(model_input)
+                with resolved_runtime_execution.autocast_context(runtime_device):
+                    logits, _embeddings = predict_fn(model_input)
                 batch_probabilities = torch.sigmoid(logits.squeeze(-1)).detach().cpu().numpy()
                 batch_labels = batch["label"].detach().cpu().numpy() if "label" in batch else np.zeros_like(batch_probabilities)
                 batch_user_ids = batch.get("user_id", list(range(len(batch_probabilities))))

--- a/src/taac2026/infrastructure/pcvr/trainer.py
+++ b/src/taac2026/infrastructure/pcvr/trainer.py
@@ -20,7 +20,13 @@ from tqdm import tqdm
 
 from taac2026.infrastructure.checkpoints import build_checkpoint_dir_name, write_checkpoint_sidecars
 from taac2026.infrastructure.pcvr.protocol import batch_to_model_input
-from taac2026.infrastructure.training.runtime import EarlyStopping, sigmoid_focal_loss
+from taac2026.infrastructure.training.runtime import (
+    EarlyStopping,
+    RuntimeExecutionConfig,
+    create_grad_scaler,
+    maybe_compile_callable,
+    sigmoid_focal_loss,
+)
 
 
 def _use_interactive_progress() -> bool:
@@ -69,6 +75,7 @@ class PCVRPointwiseTrainer:
         ns_groups_path: str | Path | None = None,
         eval_every_n_steps: int = 0,
         train_config: dict[str, Any] | None = None,
+        runtime_execution: RuntimeExecutionConfig | None = None,
     ) -> None:
         self.model = model
         self.model_input_type = model_input_type
@@ -119,6 +126,18 @@ class PCVRPointwiseTrainer:
         self.device = device
         self.save_dir = Path(save_dir).expanduser().resolve()
         self.early_stopping = early_stopping
+        self.runtime_execution = runtime_execution or RuntimeExecutionConfig()
+        self.forward_model = maybe_compile_callable(
+            self.model,
+            enabled=self.runtime_execution.compile,
+            label="PCVR training forward",
+        )
+        self.predict_fn = maybe_compile_callable(
+            self.model.predict,
+            enabled=self.runtime_execution.compile,
+            label="PCVR trainer predict",
+        )
+        self.grad_scaler = create_grad_scaler(self.runtime_execution, self.device)
         self.loss_type = loss_type
         self.focal_alpha = focal_alpha
         self.focal_gamma = focal_gamma
@@ -138,6 +157,7 @@ class PCVRPointwiseTrainer:
             focal_gamma,
             reinit_sparse_after_epoch,
         )
+        logging.info("PCVRPointwiseTrainer runtime: %s", self.runtime_execution.summary(self.device))
 
     def _build_step_dir_name(self, global_step: int, is_best: bool = False) -> str:
         return build_checkpoint_dir_name(global_step, self.ckpt_params, is_best=is_best)
@@ -345,18 +365,32 @@ class PCVRPointwiseTrainer:
             self.sparse_optimizer.zero_grad()
 
         model_input = self._make_model_input(device_batch)
-        logits = self.model(model_input).squeeze(-1)
+        with self.runtime_execution.autocast_context(self.device):
+            logits = self.forward_model(model_input).squeeze(-1)
 
-        if self.loss_type == "focal":
-            loss = sigmoid_focal_loss(logits, label, alpha=self.focal_alpha, gamma=self.focal_gamma)
+            if self.loss_type == "focal":
+                loss = sigmoid_focal_loss(logits, label, alpha=self.focal_alpha, gamma=self.focal_gamma)
+            else:
+                loss = F.binary_cross_entropy_with_logits(logits, label)
+
+        if self.grad_scaler is not None:
+            self.grad_scaler.scale(loss).backward()
+            self.grad_scaler.unscale_(self.dense_optimizer)
+            if self.sparse_optimizer is not None:
+                self.grad_scaler.unscale_(self.sparse_optimizer)
+            torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=1.0, foreach=False)
+
+            self.grad_scaler.step(self.dense_optimizer)
+            if self.sparse_optimizer is not None:
+                self.grad_scaler.step(self.sparse_optimizer)
+            self.grad_scaler.update()
         else:
-            loss = F.binary_cross_entropy_with_logits(logits, label)
-        loss.backward()
-        torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=1.0, foreach=False)
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=1.0, foreach=False)
 
-        self.dense_optimizer.step()
-        if self.sparse_optimizer is not None:
-            self.sparse_optimizer.step()
+            self.dense_optimizer.step()
+            if self.sparse_optimizer is not None:
+                self.sparse_optimizer.step()
 
         return loss.item()
 
@@ -430,7 +464,8 @@ class PCVRPointwiseTrainer:
         label = device_batch["label"]
 
         model_input = self._make_model_input(device_batch)
-        logits, _embeddings = self.model.predict(model_input)
+        with self.runtime_execution.autocast_context(self.device):
+            logits, _embeddings = self.predict_fn(model_input)
         logits = logits.squeeze(-1)
 
         return logits, label

--- a/src/taac2026/infrastructure/pcvr/training.py
+++ b/src/taac2026/infrastructure/pcvr/training.py
@@ -20,7 +20,13 @@ from taac2026.infrastructure.pcvr.protocol import (
     resolve_schema_path,
 )
 from taac2026.infrastructure.pcvr.trainer import PCVRPointwiseTrainer
-from taac2026.infrastructure.training.runtime import EarlyStopping, create_logger, set_seed
+from taac2026.infrastructure.training.runtime import (
+    AMP_DTYPE_CHOICES,
+    EarlyStopping,
+    RuntimeExecutionConfig,
+    create_logger,
+    set_seed,
+)
 
 
 def parse_pcvr_train_args(
@@ -42,6 +48,15 @@ def parse_pcvr_train_args(
     parser.add_argument("--patience", type=int, default=5)
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    parser.add_argument("--amp", action=argparse.BooleanOptionalAction, default=False)
+    parser.add_argument(
+        "--amp_dtype",
+        "--amp-dtype",
+        dest="amp_dtype",
+        default="bfloat16",
+        choices=AMP_DTYPE_CHOICES,
+    )
+    parser.add_argument("--compile", action=argparse.BooleanOptionalAction, default=False)
 
     parser.add_argument("--num_workers", type=int, default=16)
     parser.add_argument("--buffer_batches", type=int, default=20)
@@ -125,6 +140,12 @@ def train_pcvr_model(
     create_logger(log_dir / "train.log")
     config = vars(args).copy()
     logging.info("Args: %s", config)
+    runtime_execution = RuntimeExecutionConfig(
+        amp=bool(args.amp),
+        amp_dtype=str(args.amp_dtype),
+        compile=bool(args.compile),
+    )
+    logging.info("Resolved PCVR training runtime: %s", runtime_execution.summary(args.device))
 
     from torch.utils.tensorboard import SummaryWriter
 
@@ -215,6 +236,7 @@ def train_pcvr_model(
             ns_groups_path=resolved_ns_groups_path,
             eval_every_n_steps=args.eval_every_n_steps,
             train_config=config,
+            runtime_execution=runtime_execution,
         )
         trainer.train()
     finally:

--- a/src/taac2026/infrastructure/training/runtime.py
+++ b/src/taac2026/infrastructure/training/runtime.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import copy
+from contextlib import AbstractContextManager, nullcontext
+from dataclasses import dataclass
 import logging
 import os
 import random
@@ -15,6 +17,86 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+
+
+AMP_DTYPE_CHOICES: tuple[str, ...] = ("bfloat16", "float16")
+_AMP_DTYPE_ALIASES = {
+    "bf16": "bfloat16",
+    "bfloat16": "bfloat16",
+    "fp16": "float16",
+    "float16": "float16",
+    "half": "float16",
+}
+
+
+def normalize_amp_dtype(value: str | None) -> str:
+    if value is None:
+        return "bfloat16"
+    normalized = str(value).strip().lower()
+    try:
+        return _AMP_DTYPE_ALIASES[normalized]
+    except KeyError as error:
+        raise ValueError(f"unsupported amp dtype: {value}") from error
+
+
+def amp_dtype_to_torch_dtype(value: str | None) -> torch.dtype:
+    normalized = normalize_amp_dtype(value)
+    if normalized == "bfloat16":
+        return torch.bfloat16
+    return torch.float16
+
+
+def _device_type(device: str | torch.device) -> str:
+    return device.type if isinstance(device, torch.device) else torch.device(device).type
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeExecutionConfig:
+    amp: bool = False
+    amp_dtype: str = "bfloat16"
+    compile: bool = False
+
+    def normalized_amp_dtype(self) -> str:
+        return normalize_amp_dtype(self.amp_dtype)
+
+    def torch_amp_dtype(self) -> torch.dtype:
+        return amp_dtype_to_torch_dtype(self.amp_dtype)
+
+    def amp_enabled_for(self, device: str | torch.device) -> bool:
+        return self.amp and _device_type(device) == "cuda" and torch.cuda.is_available()
+
+    def grad_scaler_enabled_for(self, device: str | torch.device) -> bool:
+        return self.amp_enabled_for(device) and self.torch_amp_dtype() == torch.float16
+
+    def autocast_context(self, device: str | torch.device) -> AbstractContextManager[None]:
+        if not self.amp_enabled_for(device):
+            return nullcontext()
+        return torch.autocast(device_type="cuda", dtype=self.torch_amp_dtype())
+
+    def summary(self, device: str | torch.device) -> str:
+        return (
+            f"amp={self.amp} (effective={self.amp_enabled_for(device)}), "
+            f"amp_dtype={self.normalized_amp_dtype()}, compile={self.compile}"
+        )
+
+
+def create_grad_scaler(
+    runtime_execution: RuntimeExecutionConfig,
+    device: str | torch.device,
+) -> torch.amp.GradScaler | None:
+    if not runtime_execution.grad_scaler_enabled_for(device):
+        return None
+    return torch.amp.GradScaler(device="cuda", enabled=True)
+
+
+def maybe_compile_callable(callable_obj, *, enabled: bool, label: str):
+    if not enabled:
+        return callable_obj
+    try:
+        return torch.compile(callable_obj)
+    except Exception as error:  # pragma: no cover - exercised via monkeypatched tests.
+        logging.warning("Failed to compile %s; falling back to eager execution: %s", label, error)
+        return callable_obj
 
 
 class LogFormatter(logging.Formatter):

--- a/tests/unit/test_evaluation_cli.py
+++ b/tests/unit/test_evaluation_cli.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from taac2026.application.evaluation.cli import parse_eval_args
+
+
+def test_parse_eval_args_accepts_runtime_flags() -> None:
+    args = parse_eval_args(
+        [
+            "infer",
+            "--dataset-path",
+            "/tmp/eval.parquet",
+            "--result-dir",
+            "/tmp/results",
+            "--amp",
+            "--amp-dtype",
+            "bfloat16",
+            "--compile",
+        ]
+    )
+
+    assert args.command == "infer"
+    assert args.amp is True
+    assert args.amp_dtype == "bfloat16"
+    assert args.compile is True

--- a/tests/unit/test_evaluation_infer_entrypoint.py
+++ b/tests/unit/test_evaluation_infer_entrypoint.py
@@ -42,6 +42,9 @@ def test_infer_entrypoint_passes_optional_runtime_overrides(monkeypatch: pytest.
     monkeypatch.setenv("EVAL_RESULT_PATH", "/tmp/results")
     monkeypatch.setenv("TAAC_INFER_BATCH_SIZE", "128")
     monkeypatch.setenv("TAAC_INFER_NUM_WORKERS", "8")
+    monkeypatch.setenv("TAAC_INFER_AMP", "1")
+    monkeypatch.setenv("TAAC_INFER_AMP_DTYPE", "float16")
+    monkeypatch.setenv("TAAC_INFER_COMPILE", "true")
     captured: list[Sequence[str]] = []
 
     def fake_evaluation_main(argv: Sequence[str]) -> None:
@@ -61,4 +64,33 @@ def test_infer_entrypoint_passes_optional_runtime_overrides(monkeypatch: pytest.
         "128",
         "--num-workers",
         "8",
+        "--amp",
+        "--amp-dtype",
+        "float16",
+        "--compile",
+    ]]
+
+
+def test_infer_entrypoint_passes_explicit_runtime_disables(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EVAL_DATA_PATH", "/tmp/eval.parquet")
+    monkeypatch.setenv("EVAL_RESULT_PATH", "/tmp/results")
+    monkeypatch.setenv("TAAC_INFER_AMP", "0")
+    monkeypatch.setenv("TAAC_INFER_COMPILE", "off")
+    captured: list[Sequence[str]] = []
+
+    def fake_evaluation_main(argv: Sequence[str]) -> None:
+        captured.append(list(argv))
+
+    monkeypatch.setattr(infer_entrypoint, "evaluation_main", fake_evaluation_main)
+
+    infer_entrypoint.main()
+
+    assert captured == [[
+        "infer",
+        "--dataset-path",
+        "/tmp/eval.parquet",
+        "--result-dir",
+        "/tmp/results",
+        "--no-amp",
+        "--no-compile",
     ]]

--- a/tests/unit/test_pcvr_infer_runtime.py
+++ b/tests/unit/test_pcvr_infer_runtime.py
@@ -8,6 +8,7 @@ import pytest
 
 from taac2026.domain.config import InferRequest
 from taac2026.infrastructure.pcvr.experiment import PCVRExperiment, _log_prediction_progress
+from taac2026.infrastructure.training.runtime import RuntimeExecutionConfig
 
 
 def _make_experiment(tmp_path: Path, *, default_train_args: tuple[str, ...] = ()) -> PCVRExperiment:
@@ -101,6 +102,87 @@ def test_infer_uses_train_config_runtime_settings(tmp_path: Path, monkeypatch: p
     assert json.loads((tmp_path / "results" / "predictions.json").read_text(encoding="utf-8")) == {
         "predictions": {"u1": 0.5},
     }
+
+
+def test_resolve_prediction_runtime_execution_falls_back_to_experiment_defaults(tmp_path: Path) -> None:
+    experiment = _make_experiment(
+        tmp_path,
+        default_train_args=("--amp", "--amp-dtype", "float16", "--compile"),
+    )
+    request = InferRequest(
+        experiment="config/symbiosis",
+        dataset_path=tmp_path / "eval.parquet",
+        schema_path=None,
+        checkpoint_path=None,
+        result_dir=tmp_path / "results",
+    )
+
+    runtime_execution, amp_source, amp_dtype_source, compile_source = experiment._resolve_prediction_runtime_execution(
+        request,
+        {},
+    )
+
+    assert runtime_execution == RuntimeExecutionConfig(amp=True, amp_dtype="float16", compile=True)
+    assert amp_source == "experiment_default_train_args"
+    assert amp_dtype_source == "experiment_default_train_args"
+    assert compile_source == "experiment_default_train_args"
+
+
+def test_infer_uses_train_config_runtime_execution(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    experiment = _make_experiment(tmp_path)
+    checkpoint_dir = tmp_path / "checkpoint"
+    checkpoint_dir.mkdir()
+    (checkpoint_dir / "model.pt").write_bytes(b"checkpoint")
+    (checkpoint_dir / "train_config.json").write_text(
+        json.dumps({"amp": True, "amp_dtype": "float16", "compile": True}),
+        encoding="utf-8",
+    )
+    captured: dict[str, object] = {}
+
+    def fake_bound_run_prediction_loop(self, **kwargs):
+        del self
+        captured.update(kwargs)
+        return {"records": [{"user_id": "u1", "score": 0.5, "target": 0.0, "timestamp": None}]}
+
+    monkeypatch.setenv("MODEL_OUTPUT_PATH", str(checkpoint_dir))
+    monkeypatch.setattr(PCVRExperiment, "_run_prediction_loop", fake_bound_run_prediction_loop)
+
+    request = InferRequest(
+        experiment="config/symbiosis",
+        dataset_path=tmp_path / "eval.parquet",
+        schema_path=None,
+        checkpoint_path=None,
+        result_dir=tmp_path / "results",
+    )
+
+    experiment.infer(request)
+
+    runtime_execution = captured["runtime_execution"]
+    assert runtime_execution == RuntimeExecutionConfig(amp=True, amp_dtype="float16", compile=True)
+
+
+def test_infer_request_runtime_settings_override_train_config(tmp_path: Path) -> None:
+    experiment = _make_experiment(tmp_path)
+    request = InferRequest(
+        experiment="config/symbiosis",
+        dataset_path=tmp_path / "eval.parquet",
+        schema_path=None,
+        checkpoint_path=None,
+        result_dir=tmp_path / "results",
+        amp=False,
+        amp_dtype="bfloat16",
+        compile=False,
+    )
+
+    runtime_execution, amp_source, amp_dtype_source, compile_source = experiment._resolve_prediction_runtime_execution(
+        request,
+        {"amp": True, "amp_dtype": "float16", "compile": True},
+    )
+
+    assert runtime_execution == RuntimeExecutionConfig(amp=False, amp_dtype="bfloat16", compile=False)
+    assert amp_source == "request"
+    assert amp_dtype_source == "request"
+    assert compile_source == "request"
 
 
 def test_log_prediction_progress_reports_rows_and_batches(caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/unit/test_pcvr_trainer.py
+++ b/tests/unit/test_pcvr_trainer.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 import logging
 
 import torch
 
 import taac2026.infrastructure.pcvr.trainer as trainer_module
 from taac2026.infrastructure.pcvr.trainer import PCVRPointwiseTrainer
-from taac2026.infrastructure.training.runtime import EarlyStopping
+from taac2026.infrastructure.training.runtime import EarlyStopping, RuntimeExecutionConfig
 
 
 class _DummyModel(torch.nn.Module):
@@ -52,3 +53,48 @@ def test_train_logs_progress_when_tqdm_is_disabled(monkeypatch, tmp_path, caplog
     assert "Train epoch 1 progress 1/4 (25.0%) | eta=0:00:03 | loss=0.5000" in messages
     assert "Train epoch 1 progress 4/4 (100.0%) | eta=0:00:00 | loss=0.2000" in messages
     assert "Epoch 1, Average Loss: 0.35" in messages
+
+
+def test_trainer_runtime_execution_wraps_train_and_predict(monkeypatch, tmp_path) -> None:
+    compile_labels: list[tuple[bool, str]] = []
+    autocast_devices: list[str] = []
+    original_autocast_context = trainer_module.RuntimeExecutionConfig.autocast_context
+
+    def fake_maybe_compile_callable(callable_obj, *, enabled: bool, label: str):
+        compile_labels.append((enabled, label))
+        return callable_obj
+
+    @contextmanager
+    def recording_autocast(self, device):
+        autocast_devices.append(str(device))
+        with original_autocast_context(self, device):
+            yield
+
+    monkeypatch.setattr(trainer_module, "maybe_compile_callable", fake_maybe_compile_callable)
+    monkeypatch.setattr(trainer_module.RuntimeExecutionConfig, "autocast_context", recording_autocast)
+
+    trainer = PCVRPointwiseTrainer(
+        model=_DummyModel(),
+        model_input_type=object,
+        train_loader=[],
+        valid_loader=[],
+        lr=1e-3,
+        num_epochs=1,
+        device="cpu",
+        save_dir=tmp_path / "checkpoints",
+        early_stopping=EarlyStopping(tmp_path / "best" / "model.pt", patience=2),
+        runtime_execution=RuntimeExecutionConfig(amp=True, amp_dtype="float16", compile=True),
+    )
+    monkeypatch.setattr(trainer, "_make_model_input", lambda batch: object())
+
+    train_loss = trainer._train_step({"label": torch.tensor([1.0])})
+    eval_logits, eval_labels = trainer._evaluate_step({"label": torch.tensor([0.0])})
+
+    assert train_loss >= 0.0
+    assert eval_logits.shape == (1,)
+    assert torch.equal(eval_labels, torch.tensor([0.0]))
+    assert compile_labels == [
+        (True, "PCVR training forward"),
+        (True, "PCVR trainer predict"),
+    ]
+    assert autocast_devices == ["cpu", "cpu"]

--- a/tests/unit/test_training_cli.py
+++ b/tests/unit/test_training_cli.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from pathlib import Path
+
+from taac2026.infrastructure.pcvr.training import parse_pcvr_train_args
 from taac2026.application.training.cli import parse_train_args
 
 
@@ -21,3 +24,14 @@ def test_parse_train_args_forwards_experiment_specific_options() -> None:
     assert args.dataset_path == "/data/train"
     assert args.schema_path == "/data/schema.json"
     assert extra == ["--batch_size", "8"]
+
+
+def test_parse_pcvr_train_args_accepts_runtime_flags(tmp_path: Path) -> None:
+    args = parse_pcvr_train_args(
+        ["--amp", "--amp-dtype", "float16", "--compile"],
+        package_dir=tmp_path,
+    )
+
+    assert args.amp is True
+    assert args.amp_dtype == "float16"
+    assert args.compile is True


### PR DESCRIPTION
## Summary
- add shared runtime execution helpers for AMP dtype normalization, autocast, GradScaler selection, and safe `torch.compile` fallback
- wire AMP and compile flags through shared PCVR train, eval, infer, and platform infer entrypoints
- apply runtime execution consistently in the pointwise trainer and shared prediction loop, and cover the new behavior with focused unit tests

## Testing
- `/desay120T/ct/dev/uid01954/TAAC_2026/.venv/bin/python -m pytest tests/unit/test_training_cli.py tests/unit/test_pcvr_trainer.py tests/unit/test_pcvr_infer_runtime.py tests/unit/test_evaluation_cli.py tests/unit/test_evaluation_infer_entrypoint.py -q`

Closes #57