### PR TITLE
Implement composable PCVR data pipeline

### DIFF
--- a/.agents/skills/pcvr-experiment-integration/SKILL.md
+++ b/.agents/skills/pcvr-experiment-integration/SKILL.md
@@ -31,6 +31,7 @@ Example:
 ```python
 from pathlib import Path
 
+from taac2026.infrastructure.pcvr.config import PCVRModelConfig, PCVRNSConfig, PCVRTrainConfig
 from taac2026.infrastructure.pcvr.experiment import PCVRExperiment
 
 
@@ -38,11 +39,9 @@ EXPERIMENT = PCVRExperiment(
     name="pcvr_example",
     package_dir=Path(__file__).resolve().parent,
     model_class_name="PCVRExampleModel",
-    default_train_args=(
-        "--ns_groups_json",
-        "ns_groups.json",
-        "--num_blocks",
-        "2",
+    train_defaults=PCVRTrainConfig(
+        model=PCVRModelConfig(num_blocks=2),
+        ns=PCVRNSConfig(groups_json="ns_groups.json"),
     ),
 )
 ```
@@ -108,8 +107,8 @@ Every PCVR experiment package must include a package-local `ns_groups.json`.
 
 Rules:
 
-- Default train args should include `--ns_groups_json ns_groups.json`.
-- Shared config in `DEFAULT_PCVR_MODEL_CONFIG` defaults to `ns_groups.json`.
+- `train_defaults` should include `PCVRNSConfig(groups_json="ns_groups.json")`.
+- Evaluation and inference must read a complete checkpoint-side `train_config.json`; missing config keys should fail instead of falling back to experiment defaults.
 - If an explicitly configured NS groups file is missing, fail fast with `FileNotFoundError`; do not silently fall back to singleton groups.
 - Checkpoints copy the resolved NS groups file as `ns_groups.json`, so evaluation and inference reuse the training grouping.
 - Keep metadata keys prefixed with `_`; the runtime only consumes `user_ns_groups` and `item_ns_groups`.

--- a/config/baseline/__init__.py
+++ b/config/baseline/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from taac2026.infrastructure.pcvr.config import PCVRDataConfig, PCVRModelConfig, PCVRNSConfig, PCVRTrainConfig
 from taac2026.infrastructure.pcvr.experiment import PCVRExperiment
 
 
@@ -11,21 +12,15 @@ EXPERIMENT = PCVRExperiment(
     name="pcvr_hyformer",
     package_dir=Path(__file__).resolve().parent,
     model_class_name="PCVRHyFormer",
-    default_train_args=(
-        "--ns_tokenizer_type",
-        "rankmixer",
-        "--user_ns_tokens",
-        "5",
-        "--item_ns_tokens",
-        "2",
-        "--num_queries",
-        "2",
-        "--ns_groups_json",
-        "ns_groups.json",
-        "--emb_skip_threshold",
-        "1000000",
-        "--num_workers",
-        "8",
+    train_defaults=PCVRTrainConfig(
+        data=PCVRDataConfig(num_workers=8),
+        model=PCVRModelConfig(num_queries=2, emb_skip_threshold=1_000_000),
+        ns=PCVRNSConfig(
+            tokenizer_type="rankmixer",
+            user_tokens=5,
+            item_tokens=2,
+            groups_json="ns_groups.json",
+        ),
     ),
 )
 

--- a/config/ctr_baseline/__init__.py
+++ b/config/ctr_baseline/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from taac2026.infrastructure.pcvr.config import PCVRDataConfig, PCVRModelConfig, PCVRNSConfig, PCVRTrainConfig
 from taac2026.infrastructure.pcvr.experiment import PCVRExperiment
 
 
@@ -11,23 +12,16 @@ EXPERIMENT = PCVRExperiment(
     name="pcvr_ctr_baseline",
     package_dir=Path(__file__).resolve().parent,
     model_class_name="PCVRCTRBaseline",
-    default_train_args=(
-        "--ns_tokenizer_type",
-        "group",
-        "--ns_groups_json",
-        "ns_groups.json",
-        "--num_blocks",
-        "2",
-        "--num_heads",
-        "4",
-        "--hidden_mult",
-        "4",
-        "--dropout_rate",
-        "0.01",
-        "--emb_skip_threshold",
-        "1000000",
-        "--num_workers",
-        "8",
+    train_defaults=PCVRTrainConfig(
+        data=PCVRDataConfig(num_workers=8),
+        model=PCVRModelConfig(
+            num_blocks=2,
+            num_heads=4,
+            hidden_mult=4,
+            dropout_rate=0.01,
+            emb_skip_threshold=1_000_000,
+        ),
+        ns=PCVRNSConfig(tokenizer_type="group", groups_json="ns_groups.json"),
     ),
 )
 

--- a/config/deepcontextnet/__init__.py
+++ b/config/deepcontextnet/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from taac2026.infrastructure.pcvr.config import PCVRDataConfig, PCVRModelConfig, PCVRNSConfig, PCVRTrainConfig
 from taac2026.infrastructure.pcvr.experiment import PCVRExperiment
 
 
@@ -11,23 +12,16 @@ EXPERIMENT = PCVRExperiment(
     name="pcvr_deepcontextnet",
     package_dir=Path(__file__).resolve().parent,
     model_class_name="PCVRDeepContextNet",
-    default_train_args=(
-        "--ns_tokenizer_type",
-        "group",
-        "--ns_groups_json",
-        "ns_groups.json",
-        "--num_blocks",
-        "3",
-        "--num_heads",
-        "4",
-        "--hidden_mult",
-        "4",
-        "--dropout_rate",
-        "0.02",
-        "--emb_skip_threshold",
-        "1000000",
-        "--num_workers",
-        "8",
+    train_defaults=PCVRTrainConfig(
+        data=PCVRDataConfig(num_workers=8),
+        model=PCVRModelConfig(
+            num_blocks=3,
+            num_heads=4,
+            hidden_mult=4,
+            dropout_rate=0.02,
+            emb_skip_threshold=1_000_000,
+        ),
+        ns=PCVRNSConfig(tokenizer_type="group", groups_json="ns_groups.json"),
     ),
 )
 

--- a/config/hyformer/__init__.py
+++ b/config/hyformer/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from taac2026.infrastructure.pcvr.config import PCVRDataConfig, PCVRModelConfig, PCVRNSConfig, PCVRTrainConfig
 from taac2026.infrastructure.pcvr.experiment import PCVRExperiment
 
 
@@ -11,29 +12,22 @@ EXPERIMENT = PCVRExperiment(
     name="pcvr_hyformer_paper",
     package_dir=Path(__file__).resolve().parent,
     model_class_name="PCVRHyFormer",
-    default_train_args=(
-        "--ns_tokenizer_type",
-        "rankmixer",
-        "--user_ns_tokens",
-        "5",
-        "--item_ns_tokens",
-        "2",
-        "--num_queries",
-        "2",
-        "--ns_groups_json",
-        "ns_groups.json",
-        "--num_blocks",
-        "2",
-        "--num_heads",
-        "4",
-        "--hidden_mult",
-        "4",
-        "--dropout_rate",
-        "0.02",
-        "--emb_skip_threshold",
-        "1000000",
-        "--num_workers",
-        "8",
+    train_defaults=PCVRTrainConfig(
+        data=PCVRDataConfig(num_workers=8),
+        model=PCVRModelConfig(
+            num_queries=2,
+            num_blocks=2,
+            num_heads=4,
+            hidden_mult=4,
+            dropout_rate=0.02,
+            emb_skip_threshold=1_000_000,
+        ),
+        ns=PCVRNSConfig(
+            tokenizer_type="rankmixer",
+            user_tokens=5,
+            item_tokens=2,
+            groups_json="ns_groups.json",
+        ),
     ),
 )
 

--- a/config/interformer/__init__.py
+++ b/config/interformer/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from taac2026.infrastructure.pcvr.config import PCVRDataConfig, PCVRModelConfig, PCVRNSConfig, PCVRTrainConfig
 from taac2026.infrastructure.pcvr.experiment import PCVRExperiment
 
 
@@ -11,23 +12,16 @@ EXPERIMENT = PCVRExperiment(
     name="pcvr_interformer",
     package_dir=Path(__file__).resolve().parent,
     model_class_name="PCVRInterFormer",
-    default_train_args=(
-        "--ns_tokenizer_type",
-        "group",
-        "--ns_groups_json",
-        "ns_groups.json",
-        "--num_blocks",
-        "2",
-        "--num_heads",
-        "4",
-        "--hidden_mult",
-        "4",
-        "--dropout_rate",
-        "0.02",
-        "--emb_skip_threshold",
-        "1000000",
-        "--num_workers",
-        "8",
+    train_defaults=PCVRTrainConfig(
+        data=PCVRDataConfig(num_workers=8),
+        model=PCVRModelConfig(
+            num_blocks=2,
+            num_heads=4,
+            hidden_mult=4,
+            dropout_rate=0.02,
+            emb_skip_threshold=1_000_000,
+        ),
+        ns=PCVRNSConfig(tokenizer_type="group", groups_json="ns_groups.json"),
     ),
 )
 

--- a/config/onetrans/__init__.py
+++ b/config/onetrans/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from taac2026.infrastructure.pcvr.config import PCVRDataConfig, PCVRModelConfig, PCVRNSConfig, PCVRTrainConfig
 from taac2026.infrastructure.pcvr.experiment import PCVRExperiment
 
 
@@ -11,27 +12,21 @@ EXPERIMENT = PCVRExperiment(
     name="pcvr_onetrans",
     package_dir=Path(__file__).resolve().parent,
     model_class_name="PCVROneTrans",
-    default_train_args=(
-        "--ns_tokenizer_type",
-        "rankmixer",
-        "--user_ns_tokens",
-        "5",
-        "--item_ns_tokens",
-        "2",
-        "--ns_groups_json",
-        "ns_groups.json",
-        "--num_blocks",
-        "2",
-        "--num_heads",
-        "4",
-        "--hidden_mult",
-        "4",
-        "--dropout_rate",
-        "0.02",
-        "--emb_skip_threshold",
-        "1000000",
-        "--num_workers",
-        "8",
+    train_defaults=PCVRTrainConfig(
+        data=PCVRDataConfig(num_workers=8),
+        model=PCVRModelConfig(
+            num_blocks=2,
+            num_heads=4,
+            hidden_mult=4,
+            dropout_rate=0.02,
+            emb_skip_threshold=1_000_000,
+        ),
+        ns=PCVRNSConfig(
+            tokenizer_type="rankmixer",
+            user_tokens=5,
+            item_tokens=2,
+            groups_json="ns_groups.json",
+        ),
     ),
 )
 

--- a/config/symbiosis/__init__.py
+++ b/config/symbiosis/__init__.py
@@ -4,43 +4,33 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from taac2026.infrastructure.pcvr.config import PCVRDataConfig, PCVRModelConfig, PCVRNSConfig, PCVRTrainConfig
 from taac2026.infrastructure.pcvr.experiment import PCVRExperiment
+from taac2026.infrastructure.training.runtime import RuntimeExecutionConfig
 
 
 EXPERIMENT = PCVRExperiment(
     name="pcvr_symbiosis",
     package_dir=Path(__file__).resolve().parent,
     model_class_name="PCVRSymbiosis",
-    default_train_args=(
-        "--batch_size",
-        "128",
-        "--amp",
-        "--amp-dtype",
-        "bfloat16",
-        "--compile",
-        "--ns_tokenizer_type",
-        "rankmixer",
-        "--user_ns_tokens",
-        "5",
-        "--item_ns_tokens",
-        "2",
-        "--ns_groups_json",
-        "ns_groups.json",
-        "--num_blocks",
-        "3",
-        "--num_heads",
-        "4",
-        "--use_rope",
-        "--rope_base",
-        "1000000.0",
-        "--hidden_mult",
-        "4",
-        "--dropout_rate",
-        "0.02",
-        "--emb_skip_threshold",
-        "1000000",
-        "--num_workers",
-        "8",
+    train_defaults=PCVRTrainConfig(
+        data=PCVRDataConfig(batch_size=128, num_workers=8),
+        runtime=RuntimeExecutionConfig(amp=True, amp_dtype="bfloat16", compile=True),
+        model=PCVRModelConfig(
+            num_blocks=3,
+            num_heads=4,
+            use_rope=True,
+            rope_base=1_000_000.0,
+            hidden_mult=4,
+            dropout_rate=0.02,
+            emb_skip_threshold=1_000_000,
+        ),
+        ns=PCVRNSConfig(
+            tokenizer_type="rankmixer",
+            user_tokens=5,
+            item_tokens=2,
+            groups_json="ns_groups.json",
+        ),
     ),
 )
 

--- a/config/symbiosis/model.py
+++ b/config/symbiosis/model.py
@@ -167,14 +167,26 @@ class UserItemGraphBlock(nn.Module):
 
 
 class UnifiedBlock(nn.Module):
-	def __init__(self, d_model: int, num_heads: int, hidden_mult: int, dropout: float, *, use_rope: bool, rope_base: float) -> None:
+	def __init__(
+		self,
+		d_model: int,
+		num_heads: int,
+		hidden_mult: int,
+		dropout: float,
+		*,
+		use_rope: bool,
+		rope_base: float,
+		use_domain_gate: bool,
+	) -> None:
 		super().__init__()
+		self.use_domain_gate = use_domain_gate
 		self.attn_norm = RMSNorm(d_model)
 		self.attention = RotarySelfAttention(d_model, num_heads, dropout, use_rope=use_rope, rope_base=rope_base)
 		self.film = nn.Linear(d_model, d_model * 2)
 		self.sequence_query_norm = RMSNorm(d_model)
 		self.sequence_norm = RMSNorm(d_model)
 		self.sequence_attention = nn.MultiheadAttention(d_model, num_heads, dropout=dropout, batch_first=True)
+		self.domain_gate = nn.Linear(d_model * 2, 1)
 		self.sequence_gate = nn.Linear(d_model * 2, d_model)
 		self.ffn_norm = RMSNorm(d_model)
 		self.ffn = SwiGLUFeedForward(d_model, hidden_mult, dropout)
@@ -184,6 +196,7 @@ class UnifiedBlock(nn.Module):
 			return tokens.new_zeros(tokens.shape)
 		query = self.sequence_query_norm(tokens)
 		updates: list[torch.Tensor] = []
+		scores: list[torch.Tensor] = []
 		for sequence_tokens, sequence_mask in zip(sequences, masks, strict=True):
 			if sequence_tokens.shape[1] == 0:
 				continue
@@ -196,8 +209,15 @@ class UnifiedBlock(nn.Module):
 			)
 			valid_rows = (~sequence_mask).any(dim=1).to(attended.dtype).view(-1, 1, 1)
 			updates.append(attended * valid_rows)
+			if self.use_domain_gate:
+				domain_score = self.domain_gate(torch.cat([tokens, attended], dim=-1))
+				domain_score = domain_score.masked_fill(valid_rows <= 0, torch.finfo(domain_score.dtype).min)
+				scores.append(domain_score)
 		if not updates:
 			return tokens.new_zeros(tokens.shape)
+		if self.use_domain_gate:
+			weights = torch.softmax(torch.stack(scores, dim=0), dim=0)
+			return (torch.stack(updates, dim=0) * weights).sum(dim=0)
 		return torch.stack(updates, dim=0).mean(dim=0)
 
 	def forward(
@@ -293,6 +313,11 @@ class PCVRSymbiosis(EmbeddingParameterMixin, nn.Module):
 		ns_tokenizer_type: str = "rankmixer",
 		user_ns_tokens: int = 5,
 		item_ns_tokens: int = 2,
+		symbiosis_use_user_item_graph: bool = True,
+		symbiosis_use_fourier_time: bool = True,
+		symbiosis_use_context_exchange: bool = True,
+		symbiosis_use_multi_scale: bool = True,
+		symbiosis_use_domain_gate: bool = False,
 	) -> None:
 		super().__init__()
 		del seq_encoder_type, seq_top_k, seq_causal, rank_mixer_mode, seq_id_threshold
@@ -301,6 +326,11 @@ class PCVRSymbiosis(EmbeddingParameterMixin, nn.Module):
 		self.action_num = action_num
 		self.num_prompt_tokens = max(1, action_num, num_queries)
 		self.seq_domains = sorted(seq_vocab_sizes)
+		self.symbiosis_use_user_item_graph = symbiosis_use_user_item_graph
+		self.symbiosis_use_fourier_time = symbiosis_use_fourier_time
+		self.symbiosis_use_context_exchange = symbiosis_use_context_exchange
+		self.symbiosis_use_multi_scale = symbiosis_use_multi_scale
+		self.symbiosis_use_domain_gate = symbiosis_use_domain_gate
 		force_auto_split = ns_tokenizer_type == "rankmixer"
 		self.user_tokenizer = NonSequentialTokenizer(user_int_feature_specs, user_ns_groups, emb_dim, d_model, user_ns_tokens, emb_skip_threshold, force_auto_split=force_auto_split)
 		self.item_tokenizer = NonSequentialTokenizer(item_int_feature_specs, item_ns_groups, emb_dim, d_model, item_ns_tokens, emb_skip_threshold, force_auto_split=force_auto_split)
@@ -313,11 +343,24 @@ class PCVRSymbiosis(EmbeddingParameterMixin, nn.Module):
 		self.num_ns = self.user_tokenizer.num_tokens + self.item_tokenizer.num_tokens
 		self.num_ns += int(user_dense_dim > 0) + int(item_dense_dim > 0)
 		self.action_prompts = nn.Parameter(torch.randn(self.num_prompt_tokens, d_model) * 0.02)
-		self.graph_blocks = nn.ModuleList(UserItemGraphBlock(d_model, num_heads, hidden_mult, dropout_rate) for _ in range(max(1, num_blocks)))
-		self.unified_blocks = nn.ModuleList(
-			UnifiedBlock(d_model, num_heads, hidden_mult, dropout_rate, use_rope=use_rope, rope_base=rope_base) for _ in range(max(1, num_blocks))
+		self.graph_blocks = nn.ModuleList(
+			UserItemGraphBlock(d_model, num_heads, hidden_mult, dropout_rate) for _ in range(max(1, num_blocks)) if symbiosis_use_user_item_graph
 		)
-		self.context_blocks = nn.ModuleList(ContextExchangeBlock(d_model, num_heads, hidden_mult, dropout_rate) for _ in range(max(1, num_blocks)))
+		self.unified_blocks = nn.ModuleList(
+			UnifiedBlock(
+				d_model,
+				num_heads,
+				hidden_mult,
+				dropout_rate,
+				use_rope=use_rope,
+				rope_base=rope_base,
+				use_domain_gate=symbiosis_use_domain_gate,
+			)
+			for _ in range(max(1, num_blocks))
+		)
+		self.context_blocks = nn.ModuleList(
+			ContextExchangeBlock(d_model, num_heads, hidden_mult, dropout_rate) for _ in range(max(1, num_blocks)) if symbiosis_use_context_exchange
+		)
 		self.unified_gate = nn.Sequential(nn.Linear(d_model * 2, d_model), nn.Sigmoid())
 		self.scale_projection = nn.Sequential(RMSNorm(d_model * 3), nn.Linear(d_model * 3, d_model), nn.SiLU())
 		self.fusion_projection = nn.Sequential(RMSNorm(d_model * 4), nn.Linear(d_model * 4, d_model), nn.SiLU())
@@ -350,9 +393,10 @@ class PCVRSymbiosis(EmbeddingParameterMixin, nn.Module):
 			time_buckets = inputs.seq_time_buckets.get(domain)
 			tokens = self.sequence_tokenizers[domain](raw_sequence, time_buckets)
 			tokens = tokens + sinusoidal_positions(tokens.shape[1], self.d_model, tokens.device).unsqueeze(0)
-			time_tokens = self.time_encoders[domain](time_buckets, dtype=tokens.dtype)
-			if time_tokens is not None:
-				tokens = tokens + time_tokens
+			if self.symbiosis_use_fourier_time:
+				time_tokens = self.time_encoders[domain](time_buckets, dtype=tokens.dtype)
+				if time_tokens is not None:
+					tokens = tokens + time_tokens
 			sequences.append(tokens)
 			masks.append(make_padding_mask(seq_len, raw_sequence.shape[2]))
 			lengths.append(seq_len)
@@ -396,7 +440,10 @@ class PCVRSymbiosis(EmbeddingParameterMixin, nn.Module):
 		context = graph_context
 		for block in self.context_blocks:
 			context = block(context, sequences, masks)
-		scale_context = self._multi_scale_context(sequences, masks, lengths, ns_tokens)
+		if self.symbiosis_use_multi_scale:
+			scale_context = self._multi_scale_context(sequences, masks, lengths, ns_tokens)
+		else:
+			scale_context = torch.zeros_like(graph_context)
 		joined = torch.cat([unified_context, context, scale_context, graph_context], dim=-1)
 		candidate = self.fusion_projection(joined)
 		blended = (unified_context + context + scale_context + graph_context) * 0.25

--- a/config/unirec/__init__.py
+++ b/config/unirec/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from taac2026.infrastructure.pcvr.config import PCVRDataConfig, PCVRModelConfig, PCVRNSConfig, PCVRTrainConfig
 from taac2026.infrastructure.pcvr.experiment import PCVRExperiment
 
 
@@ -11,27 +12,21 @@ EXPERIMENT = PCVRExperiment(
     name="pcvr_unirec",
     package_dir=Path(__file__).resolve().parent,
     model_class_name="PCVRUniRec",
-    default_train_args=(
-        "--ns_tokenizer_type",
-        "rankmixer",
-        "--user_ns_tokens",
-        "5",
-        "--item_ns_tokens",
-        "2",
-        "--ns_groups_json",
-        "ns_groups.json",
-        "--num_blocks",
-        "3",
-        "--num_heads",
-        "4",
-        "--hidden_mult",
-        "4",
-        "--dropout_rate",
-        "0.02",
-        "--emb_skip_threshold",
-        "1000000",
-        "--num_workers",
-        "8",
+    train_defaults=PCVRTrainConfig(
+        data=PCVRDataConfig(num_workers=8),
+        model=PCVRModelConfig(
+            num_blocks=3,
+            num_heads=4,
+            hidden_mult=4,
+            dropout_rate=0.02,
+            emb_skip_threshold=1_000_000,
+        ),
+        ns=PCVRNSConfig(
+            tokenizer_type="rankmixer",
+            user_tokens=5,
+            item_tokens=2,
+            groups_json="ns_groups.json",
+        ),
     ),
 )
 

--- a/config/uniscaleformer/__init__.py
+++ b/config/uniscaleformer/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from taac2026.infrastructure.pcvr.config import PCVRDataConfig, PCVRModelConfig, PCVRNSConfig, PCVRTrainConfig
 from taac2026.infrastructure.pcvr.experiment import PCVRExperiment
 
 
@@ -11,27 +12,21 @@ EXPERIMENT = PCVRExperiment(
     name="pcvr_uniscaleformer",
     package_dir=Path(__file__).resolve().parent,
     model_class_name="PCVRUniScaleFormer",
-    default_train_args=(
-        "--ns_tokenizer_type",
-        "rankmixer",
-        "--user_ns_tokens",
-        "5",
-        "--item_ns_tokens",
-        "2",
-        "--ns_groups_json",
-        "ns_groups.json",
-        "--num_blocks",
-        "4",
-        "--num_heads",
-        "4",
-        "--hidden_mult",
-        "4",
-        "--dropout_rate",
-        "0.02",
-        "--emb_skip_threshold",
-        "1000000",
-        "--num_workers",
-        "8",
+    train_defaults=PCVRTrainConfig(
+        data=PCVRDataConfig(num_workers=8),
+        model=PCVRModelConfig(
+            num_blocks=4,
+            num_heads=4,
+            hidden_mult=4,
+            dropout_rate=0.02,
+            emb_skip_threshold=1_000_000,
+        ),
+        ns=PCVRNSConfig(
+            tokenizer_type="rankmixer",
+            user_tokens=5,
+            item_tokens=2,
+            groups_json="ns_groups.json",
+        ),
     ),
 )
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,6 +55,7 @@ TAAC_2026/
 ```python
 from pathlib import Path
 
+from taac2026.infrastructure.pcvr.config import PCVRModelConfig, PCVRNSConfig, PCVRTrainConfig
 from taac2026.infrastructure.pcvr.experiment import PCVRExperiment
 
 
@@ -62,11 +63,9 @@ EXPERIMENT = PCVRExperiment(
     name="pcvr_example",
     package_dir=Path(__file__).resolve().parent,
     model_class_name="PCVRExampleModel",
-    default_train_args=(
-        "--ns_groups_json",
-        "ns_groups.json",
-        "--num_blocks",
-        "2",
+    train_defaults=PCVRTrainConfig(
+        model=PCVRModelConfig(num_blocks=2),
+        ns=PCVRNSConfig(groups_json="ns_groups.json"),
     ),
 )
 ```
@@ -118,10 +117,10 @@ ModelInput
 
 ## NS Groups
 
-每个 PCVR 实验包都应包含 `ns_groups.json`，并在默认训练参数中传入：
+每个 PCVR 实验包都应包含 `ns_groups.json`，并在 typed 默认训练配置中传入：
 
 ```python
-default_train_args=("--ns_groups_json", "ns_groups.json", ...)
+train_defaults=PCVRTrainConfig(ns=PCVRNSConfig(groups_json="ns_groups.json"))
 ```
 
 runtime 会把 JSON 中的 fid 分组映射到当前 schema 的特征索引。显式配置的 NS groups 文件缺失时会直接失败，避免悄悄退化为 singleton 分组。checkpoint 会复制训练使用的 `ns_groups.json`，让评估和推理复用同一套分组。

--- a/docs/experiments/baseline.md
+++ b/docs/experiments/baseline.md
@@ -61,7 +61,7 @@ checkpoint 目录名以 `global_step` 开头，并可带 `layer`、`head`、`hid
 - `train_config.json`：模型结构与数据加载超参数的单一来源。
 - `ns_groups.json`：如果训练启用了 NS 分组，则复制到 checkpoint 目录内。
 
-评分 baseline 会优先使用 checkpoint 内的 `schema.json` 和 `train_config.json` 重建模型；如果缺少 `train_config.json`，只会退回硬编码默认值，非默认训练很容易发生 shape mismatch。因此当前共享 runtime 也把 checkpoint 侧车文件视为训练与推理一致性的核心契约。
+评分 baseline 会使用 checkpoint 内的 `schema.json` 和 `train_config.json` 重建模型；如果缺少 `train_config.json` 或其中缺少必要字段，当前共享 runtime 会直接失败，避免用隐式默认值重建出与训练不一致的模型。
 
 ## 评分输出
 

--- a/docs/experiments/symbiosis.md
+++ b/docs/experiments/symbiosis.md
@@ -15,18 +15,12 @@ config/symbiosis/
 └── ns_groups.json
 ```
 
-`__init__.py` 中的默认训练参数包括：
+`__init__.py` 中的 `train_defaults` 包括：
 
-- `--ns_tokenizer_type rankmixer`
-- `--user_ns_tokens 5`
-- `--item_ns_tokens 2`
-- `--ns_groups_json ns_groups.json`
-- `--num_blocks 3`
-- `--num_heads 4`
-- `--use_rope`
-- `--rope_base 1000000.0`
-- `--hidden_mult 4`
-- `--dropout_rate 0.02`
+- `PCVRNSConfig(tokenizer_type="rankmixer", user_tokens=5, item_tokens=2, groups_json="ns_groups.json")`
+- `PCVRModelConfig(num_blocks=3, num_heads=4, use_rope=True, rope_base=1000000.0, hidden_mult=4, dropout_rate=0.02)`
+- `PCVRDataConfig(batch_size=128, num_workers=8)`
+- `RuntimeExecutionConfig(amp=True, amp_dtype="bfloat16", compile=True)`
 
 ## 模型思路
 
@@ -49,6 +43,29 @@ bash run.sh train --experiment config/symbiosis \
     --num_epochs 1 \
     --batch_size 8 \
     --device cpu
+```
+
+## 消融开关
+
+Symbiosis 支持一组实验开关，用于按计划验证现有模块是否真正贡献 AUC。默认值保持当前模型行为不变。
+
+| 参数 | 默认 | 作用 |
+| --- | --- | --- |
+| `--symbiosis-use-user-item-graph` / `--no-symbiosis-use-user-item-graph` | 开启 | 启停 `UserItemGraphBlock` |
+| `--symbiosis-use-fourier-time` / `--no-symbiosis-use-fourier-time` | 开启 | 启停额外 Fourier time encoder |
+| `--symbiosis-use-context-exchange` / `--no-symbiosis-use-context-exchange` | 开启 | 启停 `ContextExchangeBlock` |
+| `--symbiosis-use-multi-scale` / `--no-symbiosis-use-multi-scale` | 开启 | 启停 mean / recent / last 多尺度序列摘要 |
+| `--symbiosis-use-domain-gate` / `--no-symbiosis-use-domain-gate` | 关闭 | 在 `UnifiedBlock` 序列读取中用可学习 domain gate 替代简单 domain mean |
+
+示例：
+
+```bash
+bash run.sh train --experiment config/symbiosis \
+    --dataset-path /path/to/parquet_or_dataset_dir \
+    --schema-path /path/to/schema.json \
+    --no-symbiosis-use-user-item-graph \
+    --no-symbiosis-use-context-exchange \
+    --symbiosis-use-domain-gate
 ```
 
 ## 评估

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -99,7 +99,7 @@ bash run.sh val --experiment config/baseline \
     --device cpu
 ```
 
-当前 PCVR 评估报告输出 `auc`、`logloss` 和 `sample_count`，并写出 `evaluation.json` 与 `validation_predictions.jsonl`。运行参数以当前 `taac-evaluate single` parser 为准。
+当前 PCVR 评估报告会在 `auc` 旁边自动输出 `auc_ci`、`logloss`、`brier`、`score_diagnostics` 和 `sample_count`，并在顶层写出 `data_diagnostics` 说明 Row Group 切分是否适合 L1 比较。评估同时写出 `evaluation.json` 与 `validation_predictions.jsonl`。运行参数以当前 `taac-evaluate single` parser 为准。
 
 ## 运行其他实验包
 

--- a/docs/guide/contributing.md
+++ b/docs/guide/contributing.md
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from taac2026.infrastructure.pcvr.config import PCVRModelConfig, PCVRNSConfig, PCVRTrainConfig
 from taac2026.infrastructure.pcvr.experiment import PCVRExperiment
 
 
@@ -33,13 +34,9 @@ EXPERIMENT = PCVRExperiment(
     name="pcvr_my_experiment",
     package_dir=Path(__file__).resolve().parent,
     model_class_name="PCVRMyExperiment",
-    default_train_args=(
-        "--ns_groups_json",
-        "ns_groups.json",
-        "--num_blocks",
-        "2",
-        "--num_heads",
-        "4",
+    train_defaults=PCVRTrainConfig(
+        model=PCVRModelConfig(num_blocks=2, num_heads=4),
+        ns=PCVRNSConfig(groups_json="ns_groups.json"),
     ),
 )
 
@@ -50,8 +47,8 @@ __all__ = ["EXPERIMENT"]
 
 - `model_class_name` 必须与 `model.py` 中导出的类名一致。
 - 非 baseline 实验使用自己的类名，例如 `PCVRInterFormer`、`PCVROneTrans` 或 `PCVRMyExperiment`。
-- `default_train_args` 里显式启用包内 `ns_groups.json`。
-- 新参数优先使用共享 PCVR parser 已支持的名字，例如 `--num_blocks`、`--d_model`、`--batch_size`。
+- `train_defaults` 里用 `PCVRNSConfig(groups_json="ns_groups.json")` 显式启用包内 `ns_groups.json`。
+- 新参数优先放进 `PCVRTrainConfig` 下已有的 typed 子配置，例如 `PCVRModelConfig.num_blocks`、`PCVRModelConfig.d_model`、`PCVRDataConfig.batch_size`。
 
 ## model.py
 
@@ -208,7 +205,7 @@ uv run pytest tests/unit -q
 
 - `model_class_name` 与 `model.py` 导出的类一致。
 - 非 baseline 包没有暴露 `PCVRHyFormer`。
-- `ns_groups.json` 存在，并在默认训练参数中启用。
+- `ns_groups.json` 存在，并在 `train_defaults` 中启用。
 - 模型能完成 forward、backward 和 predict。
 - Bundle 包含目标实验包的 `model.py` 和 `ns_groups.json`。
 - 文档中的命令都显式给出数据路径，且只使用当前 CLI 支持的参数。

--- a/docs/guide/pcvr-data-pipeline.md
+++ b/docs/guide/pcvr-data-pipeline.md
@@ -1,0 +1,361 @@
+---
+icon: lucide/database-zap
+---
+
+# PCVR 数据管道
+
+PCVR 共享 runtime 的数据路径分为几层：
+
+| 层                | 位置                                         | 职责                                                              |
+| ----------------- | -------------------------------------------- | ----------------------------------------------------------------- |
+| Row Group 规划    | `taac2026.infrastructure.pcvr.data`          | 收集 parquet Row Group，并生成 train/valid 切分计划               |
+| 基础读取转换      | `PCVRParquetDataset`                         | 解析 `schema.json`，把 Arrow batch 转为预分批 tensor dict         |
+| 组合式 batch 组件 | `taac2026.infrastructure.pcvr.data_pipeline` | 内存 cache、batch transform、row-level shuffle buffer、训练期增广 |
+| 训练装配          | `get_pcvr_data`                              | 创建 train/valid dataset 和 DataLoader                            |
+
+评估和推理路径仍然直接创建无增广的 `PCVRParquetDataset`，保持确定性。
+
+## 实验侧组合
+
+推荐在 experiment package 的 `train_defaults` 中像模型配置一样组装数据管道：
+
+```python
+from taac2026.infrastructure.pcvr.config import (
+    PCVRDataCacheConfig,
+    PCVRDataPipelineConfig,
+    PCVRDomainDropoutConfig,
+    PCVRFeatureMaskConfig,
+    PCVRSequenceCropConfig,
+    PCVRTrainConfig,
+)
+
+
+train_defaults = PCVRTrainConfig(
+    data_pipeline=PCVRDataPipelineConfig(
+        cache=PCVRDataCacheConfig(mode="memory", max_batches=256),
+        seed=42,
+        strict_time_filter=True,
+        transforms=(
+            PCVRSequenceCropConfig(
+                views_per_row=2,
+                seq_window_mode="random_tail",
+                seq_window_min_len=8,
+            ),
+            PCVRFeatureMaskConfig(probability=0.05),
+            PCVRDomainDropoutConfig(probability=0.05),
+        ),
+    ),
+)
+```
+
+`transforms` 元组顺序就是实际执行顺序；可以只放一个 transform，也可以调换顺序或关闭某个组件。默认 `PCVRDataPipelineConfig()` 没有 transform、没有 cache，训练行为保持旧逻辑。
+
+增广 transform 只装配到 train dataset。valid dataset 会保留 cache 配置但不接收 transform，离线 evaluation 和线上 inference 也不接收训练期增广。
+
+训练 CLI 不提供数据管道覆盖参数。数据管道属于 experiment package 的 typed contract，和模型结构默认值一起由 `PCVRTrainConfig` 管理；需要比较不同数据管道时，应创建或调整对应 experiment package 的 `train_defaults`。
+
+## 组件说明
+
+### `PCVRDataPipelineConfig`
+
+这是数据管道的总装配点，负责把 cache、随机种子、时间安全过滤和 transform 序列绑定到一个 experiment 的 `train_defaults`。它本身不做数据修改，只描述 runtime 应该如何组合组件。
+
+常用字段：
+
+| 字段                 | 作用                                       | 建议                                   |
+| -------------------- | ------------------------------------------ | -------------------------------------- |
+| `cache`              | 配置基础 batch cache                       | 多 epoch 或重复扫描 Row Group 时再开启 |
+| `transforms`         | 按顺序执行的 batch transform 元组          | 从轻量组件开始逐个加，不要一次堆满     |
+| `seed`               | 控制 crop、mask、dropout 的 batch 级随机性 | 消融实验固定 seed，正式多 seed 复核    |
+| `strict_time_filter` | 在增广前移除未来序列事件                   | 默认保持 `True`，除非明确做吞吐对照    |
+
+最小空管道：
+
+```python
+from taac2026.infrastructure.pcvr.config import PCVRDataPipelineConfig, PCVRTrainConfig
+
+
+train_defaults = PCVRTrainConfig(
+    data_pipeline=PCVRDataPipelineConfig(),
+)
+```
+
+### `PCVRDataCacheConfig`
+
+内存 cache 缓存的是 Arrow batch 转换后的基础 tensor dict，也就是增广之前的 batch。后续 transform 会拿到 clone，因此不会污染 cache 中的原始数据。
+
+适合场景：
+
+- 多 epoch 训练，同一 worker 会重复扫到相同 Row Group。
+- `persistent_workers=True` 时，worker 内 cache 能跨 epoch 保留。
+- 正在调增广组件，希望减少基础 parquet 转换开销对 benchmark 的干扰。
+
+不适合场景：
+
+- 单 epoch、超大数据流式训练，重复命中率低。
+- `max_batches` 设得过大导致 worker 内存压力明显上升。
+
+cache-only 示例：
+
+```python
+from taac2026.infrastructure.pcvr.config import (
+    PCVRDataCacheConfig,
+    PCVRDataPipelineConfig,
+    PCVRTrainConfig,
+)
+
+
+train_defaults = PCVRTrainConfig(
+    data_pipeline=PCVRDataPipelineConfig(
+        cache=PCVRDataCacheConfig(mode="memory", max_batches=512),
+    ),
+)
+```
+
+### `PCVRSequenceCropConfig`
+
+`sequence_crop` 对每一行的序列域生成一个或多个窗口视图，核心用途是让模型在训练期见到不同长度、不同近期窗口的行为历史。它会同步裁剪序列 token、`*_len` 和 `*_time_bucket`。
+
+参数含义：
+
+| 字段                            | 作用                     | 例子                       |
+| ------------------------------- | ------------------------ | -------------------------- |
+| `views_per_row`                 | 每条样本扩成几个训练视图 | `2` 表示一行变两行         |
+| `seq_window_mode="tail"`        | 保留完整尾部窗口         | 稳定、接近原始读取         |
+| `seq_window_mode="random_tail"` | 随机选择尾部窗口长度     | 模拟近期历史长度变化       |
+| `seq_window_mode="rolling"`     | 随机选择任意连续窗口     | 更强扰动，适合长序列鲁棒性 |
+| `seq_window_min_len`            | 随机窗口最短长度         | 避免裁得过短导致噪声过大   |
+
+轻量近期窗口示例：
+
+```python
+from taac2026.infrastructure.pcvr.config import (
+    PCVRDataPipelineConfig,
+    PCVRSequenceCropConfig,
+    PCVRTrainConfig,
+)
+
+
+train_defaults = PCVRTrainConfig(
+    data_pipeline=PCVRDataPipelineConfig(
+        seed=2026,
+        transforms=(
+            PCVRSequenceCropConfig(
+                views_per_row=2,
+                seq_window_mode="random_tail",
+                seq_window_min_len=8,
+            ),
+        ),
+    ),
+)
+```
+
+使用建议：先从 `views_per_row=2` 开始。它会增加训练样本数和 loader 开销，收益需要用 AUC、logloss 和吞吐一起判断。
+
+### `PCVRFeatureMaskConfig`
+
+`feature_mask` 会随机把非序列 sparse 特征和有效序列事件置零，并压紧序列长度。它模拟特征缺失、采集失败、部分历史行为不可见等情况，目标是减少模型对单个 id 或单个事件的过拟合。
+
+适合场景：
+
+- 模型对少数高频 user/item sparse 特征依赖过强。
+- 线上特征缺失或延迟到达较常见。
+- 需要让序列 encoder 对缺失事件更稳健。
+
+保守 feature mask 示例：
+
+```python
+from taac2026.infrastructure.pcvr.config import (
+    PCVRDataPipelineConfig,
+    PCVRFeatureMaskConfig,
+    PCVRTrainConfig,
+)
+
+
+train_defaults = PCVRTrainConfig(
+    data_pipeline=PCVRDataPipelineConfig(
+        seed=42,
+        transforms=(PCVRFeatureMaskConfig(probability=0.02),),
+    ),
+)
+```
+
+使用建议：`probability` 从 `0.01` 到 `0.05` 之间扫起。过高会让训练分布偏离真实样本，尤其是当前数据已经稀疏时。
+
+### `PCVRDomainDropoutConfig`
+
+`domain_dropout` 会按行丢弃整个序列域，例如某一行的 `seq_b` 被清零且长度归零。它模拟某个行为域完全缺失，也能迫使模型不要只依赖单一强 domain。
+
+适合场景：
+
+- 多个 sequence domain 信息量不均衡，模型过度依赖最强 domain。
+- 线上某些 domain 覆盖率不稳定。
+- 想验证模型在 domain 缺失切片上的鲁棒性。
+
+序列域鲁棒性示例：
+
+```python
+from taac2026.infrastructure.pcvr.config import (
+    PCVRDataPipelineConfig,
+    PCVRDomainDropoutConfig,
+    PCVRTrainConfig,
+)
+
+
+train_defaults = PCVRTrainConfig(
+    data_pipeline=PCVRDataPipelineConfig(
+        seed=42,
+        transforms=(PCVRDomainDropoutConfig(probability=0.05),),
+    ),
+)
+```
+
+使用建议：先从 `0.02` 或 `0.05` 开始。它比单点 feature mask 更强，可能提升缺失 domain 切片，但也可能伤害全量 AUC。
+
+### `PCVRShuffleBuffer`
+
+shuffle buffer 不是 experiment 侧显式配置的 transform，而是 `get_pcvr_data` 用 `buffer_batches` 控制的 row-level shuffle 组件。它把多个预分批 batch 合并后按行打散，再切回 batch，减少 Row Group 内部顺序对训练的影响。
+
+使用建议：
+
+- `buffer_batches=1` 基本等于不做跨 batch shuffle，吞吐最高，适合 loader benchmark。
+- `buffer_batches=20` 更接近训练默认值，随机性更好但会增加 tensor 拼接和 row slicing 开销。
+- 做模型训练对比时固定 `buffer_batches`，否则随机性和吞吐都会变。
+
+## 组合例子
+
+### 保守鲁棒性组合
+
+适合先做 A/B 的第一组增广：轻量 crop 加低概率 mask，不启用 domain dropout。
+
+```python
+from taac2026.infrastructure.pcvr.config import (
+    PCVRDataCacheConfig,
+    PCVRDataPipelineConfig,
+    PCVRFeatureMaskConfig,
+    PCVRSequenceCropConfig,
+    PCVRTrainConfig,
+)
+
+
+train_defaults = PCVRTrainConfig(
+    data_pipeline=PCVRDataPipelineConfig(
+        cache=PCVRDataCacheConfig(mode="memory", max_batches=256),
+        seed=42,
+        strict_time_filter=True,
+        transforms=(
+            PCVRSequenceCropConfig(
+                views_per_row=2,
+                seq_window_mode="random_tail",
+                seq_window_min_len=8,
+            ),
+            PCVRFeatureMaskConfig(probability=0.02),
+        ),
+    ),
+)
+```
+
+### 强鲁棒性组合
+
+适合在有足够大验证集时测试，重点观察长序列、domain 缺失和低频 item 切片。
+
+```python
+from taac2026.infrastructure.pcvr.config import (
+    PCVRDataPipelineConfig,
+    PCVRDomainDropoutConfig,
+    PCVRFeatureMaskConfig,
+    PCVRSequenceCropConfig,
+    PCVRTrainConfig,
+)
+
+
+train_defaults = PCVRTrainConfig(
+    data_pipeline=PCVRDataPipelineConfig(
+        seed=2026,
+        strict_time_filter=True,
+        transforms=(
+            PCVRSequenceCropConfig(
+                views_per_row=2,
+                seq_window_mode="rolling",
+                seq_window_min_len=16,
+            ),
+            PCVRFeatureMaskConfig(probability=0.05),
+            PCVRDomainDropoutConfig(probability=0.05),
+        ),
+    ),
+)
+```
+
+### 消融用单组件组合
+
+每次只开一个组件，方便判断收益来自哪里：
+
+```python
+from taac2026.infrastructure.pcvr.config import (
+    PCVRDataPipelineConfig,
+    PCVRDomainDropoutConfig,
+    PCVRTrainConfig,
+)
+
+
+train_defaults = PCVRTrainConfig(
+    data_pipeline=PCVRDataPipelineConfig(
+        seed=7,
+        transforms=(PCVRDomainDropoutConfig(probability=0.03),),
+    ),
+)
+```
+
+## 后续可扩展的增广组件
+
+下面这些组件目前还没有实现，适合作为下一轮数据管道扩展候选。实现时仍建议保持 typed config 形态，例如 `PCVRTimeJitterConfig`、`PCVRSequenceEventDropConfig` 这类独立配置对象，并继续只在 train dataset 装配。
+
+| 组件想法                 | 作用                                                                        | 关键参数                                    | 主要风险                                    |
+| ------------------------ | --------------------------------------------------------------------------- | ------------------------------------------- | ------------------------------------------- |
+| `sequence_event_drop`    | 随机删除序列中的部分有效事件，比 feature mask 更专注序列历史                | `probability`, `min_remaining_events`       | 删除过多会破坏真实兴趣轨迹                  |
+| `sequence_tail_truncate` | 只随机截断尾部最近若干事件，模拟日志延迟或近期行为缺失                      | `max_drop_events`, `probability`            | 可能伤害强近期信号                          |
+| `time_jitter`            | 对历史事件 timestamp 或 time bucket 加小扰动，降低对精确时间桶过拟合        | `max_seconds`, `probability`                | 必须保持事件仍早于样本 timestamp            |
+| `domain_permutation`     | 随机打乱同一 domain 内部分非时间关键 side feature，测试模型是否依赖偶然共现 | `feature_ids`, `probability`                | 容易制造不真实样本，需谨慎                  |
+| `feature_value_dropout`  | 只对指定 user/item fid 做 dropout，而不是所有 sparse 特征同概率             | `feature_ids`, `probability`                | 需要 schema fid 白名单，配置更复杂          |
+| `dense_noise`            | 给 user dense 特征加小幅高斯噪声，提升 dense embedding 鲁棒性               | `std`, `feature_ids`                        | dense 特征可能已经归一化，噪声尺度要小      |
+| `negative_resample`      | 对 batch 内负样本做轻量重采样或重权重，改善正负排序学习                     | `negative_ratio`, `hard_negative_score_key` | 会改变训练分布，必须看 logloss 和校准       |
+| `mixup_embeddings_input` | 在 tensor batch 层对 dense 特征做 mixup，label 做软混合                     | `alpha`, `probability`                      | sparse/序列字段不适合直接 mixup，设计要克制 |
+| `domain_token_mask`      | 只 mask 某些 domain 的某些 side feature，不丢整域                           | `domain`, `feature_slots`, `probability`    | 需要把 schema fid 映射到 sequence slot      |
+| `recent_history_swap`    | 在同一 batch、同类 label 或同 user 活跃度桶内交换少量近期事件               | `swap_probability`, `bucket_key`            | 很容易引入语义噪声，优先级低                |
+
+优先级建议：先做 `sequence_event_drop`、`feature_value_dropout`、`dense_noise`。这三类最容易和现有 batch dict 对齐，风险可控，也能分别覆盖序列缺失、稀疏特征缺失和 dense 特征扰动。`negative_resample` 更接近采样策略或 loss 设计，建议等基础增广组件的收益确认后再做。
+
+## 时间安全
+
+当增广配置启用且 `strict_time_filter=True` 时，序列转换阶段会先按样本级 `timestamp` 过滤事件：事件 timestamp 必须为正，并且严格早于样本 timestamp。过滤后的序列再进入 crop、masking 和 shuffle buffer。
+
+没有开启增广时，默认训练命令保持原始读取行为。
+
+## 内存 Cache
+
+数据 cache 是 per-process LRU cache，缓存的是增广前的基础 tensor batch。它适合多 epoch、`persistent_workers` 或重复扫描同一 Row Group 的训练场景。
+
+cache 会返回 clone，后续增广和 shuffle 不会污染缓存中的基础 batch。
+
+## 吞吐压测
+
+本地样本只有 1000 行、单个 Row Group，只适合 smoke。需要压测数据管道时，可以先生成 100x 放大模拟集：
+
+```bash
+uv run python tools/generate_pcvr_synthetic_dataset.py --force
+```
+
+默认输出到 `outputs/perf/pcvr_synthetic_100x/`，包含 100000 行和 100 个 Row Group，并复用 `sample_1000_raw` 的真实 schema。
+
+然后只跑 loader，不跑模型：
+
+```bash
+uv run python tools/benchmark_pcvr_data_pipeline.py \
+    --dataset-path outputs/perf/pcvr_synthetic_100x/demo_100000.parquet \
+    --schema-path outputs/perf/pcvr_synthetic_100x/schema.json \
+    --batch-size 256 \
+    --num-workers 0 \
+    --buffer-batches 1
+```
+
+增广路径可以用 `--pipeline-preset augment` 单独压测；训练入口本身仍然不提供数据管道覆盖参数。

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -43,6 +43,7 @@ uv run --with ruff ruff check src/taac2026 tests/unit
 | `tests/unit/test_package_training.py`        | `run.sh` + `code_package.zip` 双文件 bundle 内容        |
 | `tests/unit/test_training_cli.py`            | 训练 CLI 参数解析和 extra args 透传                     |
 | `tests/unit/test_pcvr_protocol.py`           | schema、特征规格、NS groups 映射与缺失文件失败          |
+| `tests/unit/test_pcvr_data_augmentation.py`  | PCVR 训练期增广、内存 cache 与时间安全过滤              |
 
 ## 模块改动后的最小复核
 
@@ -50,6 +51,7 @@ uv run --with ruff ruff check src/taac2026 tests/unit
 | ------------------------------------ | --------------------------------------------------------------------------------------------- |
 | 实验包 `config/<name>/`              | `uv run pytest tests/unit/test_experiment_packages.py -q`                                     |
 | `ns_groups.json` 或 PCVR schema 解析 | `uv run pytest tests/unit/test_pcvr_protocol.py tests/unit/test_experiment_packages.py -q`    |
+| PCVR 数据管道、增广或 cache          | `uv run pytest tests/unit/test_pcvr_data_augmentation.py tests/unit/test_pcvr_data_split.py -q` |
 | 线上打包                             | `uv run pytest tests/unit/test_package_training.py -q`                                        |
 | 训练入口参数                         | `uv run pytest tests/unit/test_training_cli.py -q`                                            |
 | checkpoint 或 loader                 | `uv run pytest tests/unit/test_checkpoint_and_loader.py -q`                                   |

--- a/docs/ideas/index.md
+++ b/docs/ideas/index.md
@@ -18,3 +18,4 @@ icon: lucide/lightbulb
 | 2026-04-12 | [从直播推荐实战看特征 Token 化、长序列注意力与辅助 Loss 设计](posts/001-rec-model-work-summary.md) | RankMixer, STCA, 行为序列融合, MoE, 生成式辅助 loss   |
 | 2026-04-14 | [腾讯广告算法大赛 2025 官方论文解读：全模态生成式推荐](posts/002-taac2025-competition-paper.md)    | 生成式推荐, 多模态, Semantic ID, InfoNCE, Scaling Law |
 | 2026-04-26 | [Learning Mechanics 分析方法：从缩放律、学习量子到低秩动力学](posts/003-learning-mechanics-analysis.md) | 学习力学, Scaling Law, Quanta, 低秩更新, 谱分析       |
+| 2026-04-28 | [Symbiosis V2 改造与实验验证计划](posts/004-symbiosis-v2-experiment-plan.md) | Symbiosis, AUC, 统一模块, 长序列, 消融实验            |

--- a/docs/ideas/posts/004-symbiosis-v2-experiment-plan.md
+++ b/docs/ideas/posts/004-symbiosis-v2-experiment-plan.md
@@ -1,0 +1,380 @@
+---
+icon: lucide/clipboard-check
+---
+
+# Symbiosis V2 改造与实验验证计划
+
+:material-calendar: 2026-04-28 · :material-tag: Symbiosis, AUC, 统一模块, 长序列, 消融实验, Scaling Law
+
+## 背景
+
+TAAC 2026 的排行榜主指标是 AUC，线上推理契约要求输出 `user_id -> probability`。因此 Symbiosis 的下一代改造不能把主线改成 HR@K / NDCG 式检索，也不能把 `predictions.json` 改成 top-k item。所有方案都必须服务于：
+
+```text
+P(label_action_type = 2 | user, candidate item, context, multi-domain history)
+```
+
+本文把前面讨论过的想法整理成可验证计划。这里的每个改造点都只是待检验假设，不预设一定有效。实验必须以当前 `config/symbiosis` 为对照，记录 AUC、logloss、推理延迟、参数量、训练稳定性和分群指标，再决定是否保留。
+
+## 对当前 Symbiosis 的客观判断
+
+当前 Symbiosis 不是一无是处。它已经具备几个值得保留或至少认真消融的资产：
+
+| 现有设计                         | 可能价值                                                         | 主要风险                                                            | 验证方式                                                   |
+| -------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------- | ---------------------------------------------------------- |
+| UserItemGraphBlock               | 在非序列 token 层提前做 user-item 双向交互，可能提高候选相关性   | 交互太早可能放大噪声或增加重复建模                                  | 与移除 graph block 的版本比较 AUC、logloss、延迟           |
+| UnifiedBlock                     | 将 prompt、非序列 token 和序列读取放进统一空间，符合统一模块主题 | 所有 domain 的序列更新被简单平均，候选相关性可能不够强              | 比较统一 block、domain-wise decoder、无统一 block 三种结构 |
+| FourierTimeEncoder               | 显式利用时间桶和周期特征，可能改善近期意图建模                   | 时间桶离散化已包含部分信息，额外 Fourier 投影可能过拟合             | 开关 time encoder，按序列长度和近期行为桶分群看 AUC        |
+| ContextExchangeBlock             | 让全局 context 从序列域读取信息，补充非序列表征                  | 单个 context query 可能过粗，无法区分 candidate 相关历史            | 与 candidate-conditioned query 比较                        |
+| 多尺度 mean / recent / last 摘要 | 低成本保留长期、近期、末次行为信号                               | `tokens.shape[1] // 2` 的 recent 定义偏粗，和真实时间近期不一定一致 | 与 top-k 最近有效 token、压缩块记忆比较                    |
+| ActionConditionedHead            | 已经有 action prototype 的雏形，兼容多 action 输出               | action 只在 head 里出现，可能太晚                                   | 与 action token 前移版本比较                               |
+
+现阶段不应该直接推翻当前 Symbiosis。更合理的做法是先做组件消融，确认哪些模块确实贡献 AUC，哪些只是增加复杂度。
+
+## 总体实验原则
+
+1. 主指标只看 validation AUC，logloss 和校准作为副指标。
+2. 任一架构改动都必须报告推理延迟；超出线上预算的 AUC 增益不计为有效收益。
+3. 每个方案先跑小样本 smoke，再跑固定 validation slice，最后才扩大到正式训练。
+4. 单次 AUC 提升小于随机波动时，不写成有效结论；关键方案至少跑 3 个 seed。
+5. 不把辅助目标、Semantic ID、compressed memory 的收益提前当真；它们只在消融中证明自己。
+6. 保留当前 PCVR package contract：`forward()` 返回 logits，`predict()` 返回 `(logits, embeddings)`，不新增 package-local trainer 或 run.sh。
+
+## 本地测试数据不足的处理
+
+当前本地样本量太小，baseline 轻松达到 0.95 AUC。这类结果不能直接作为模型选择依据，因为它通常意味着验证集过容易、方差过大，或者存在与线上分布不一致的采样偏差。小样本本地评估应定位为 smoke test：验证代码能跑通、loss 不崩、输出概率合法、推理延迟大致可控，而不是判断一个架构改动是否真的有效。
+
+后续实验需要把验证可信度分成三层：
+
+| 层级                                 | 数据来源                           | 主要用途                                  | 结论可信度                 |
+| ------------------------------------ | ---------------------------------- | ----------------------------------------- | -------------------------- |
+| L0 smoke                             | `sample_1000` 或同等小样本         | 检查 forward/backward、打包、推理、无 NaN | 只能证明没坏，不能证明有效 |
+| L1 internal validation               | 从可用训练数据中切出的固定大验证集 | 比较消融、loss、架构改动                  | 可做阶段性模型选择         |
+| L2 platform / hidden-like validation | 官方平台或尽量贴近线上分布的大样本 | 最终保留或淘汰方案                        | 才能作为真实收益判断       |
+
+在 L0/L1 数据有限时，必须增加不确定性估计：
+
+- 对 validation 预测做 bootstrap，报告 AUC 的 95% 置信区间。
+- 对关键方案至少跑 3 个 seed，报告 mean、std 和最差 seed。
+- 对同一批预测同时看 AUC、logloss、score margin、正负样本分数分布，避免只看一个饱和 AUC。
+- 对序列长度、item 频率、用户活跃度、domain 缺失模式做切片；如果整体 AUC 饱和，切片 AUC 往往更能暴露差异。
+- 如果一个改动只在 `sample_1000` 上提升，但 bootstrap 置信区间高度重叠，则视为无结论。
+- 如果一个改动在小样本上 AUC 不升但延迟、稳定性或分群指标明显变好，只能标为“值得上大样本复核”，不能直接保留。
+
+实操上，任何小于 0.001 的 AUC 差异都不应在小样本上解读为有效收益；即使大于 0.001，也必须通过 bootstrap 和多 seed 确认。若 baseline 已经接近 0.95，应优先寻找更难的验证切片，例如长序列用户、低频 item、domain 缺失样本、近期行为弱相关样本，而不是继续在整体 AUC 上做细微比较。
+
+后续 L1 消融应直接使用 `taac-evaluate single`。评估输出的 `metrics` 会和 `auc` 一起写出 `auc_ci`、`logloss`、`brier`、`score_diagnostics` 和 `sample_count`；顶层 `data_diagnostics` 会同时记录 parquet Row Group 数量、默认 train/valid 切分是否复用、是否适合 L1 比较。只有当 `data_diagnostics.row_group_split.is_l1_ready=true`、`reuse_train_for_valid=false`、`is_disjoint=true` 时，才把这份数据用于模型优劣比较。若像 `sample_1000` 一样只有单个 Row Group，评估报告会标为 L0-only，只能做链路 smoke。
+
+不同 run 之间不再依赖单独的分析 CLI。比较时先看每个 run 自带的 `auc_ci` 是否与 baseline 明显分离；若置信区间重叠，结论应标为“无结论”或“需要更大验证集 / 多 seed”。
+
+## 实验基线
+
+| 基线                       | 目的                                                | 预期结果                                              | 判定标准                              |
+| -------------------------- | --------------------------------------------------- | ----------------------------------------------------- | ------------------------------------- |
+| B0: baseline 官方 HyFormer | 官方参考下限                                        | AUC 稳定、延迟较低                                    | 所有方案必须至少与它比较              |
+| B1: 当前 Symbiosis         | 当前融合式实现                                      | 可能高于 baseline，也可能因复杂度和训练不充分表现不稳 | 作为所有 Symbiosis V2 方案的主对照    |
+| B2: Symbiosis-lite         | 保留 tokenizer、time、multi-scale，去掉较重统一交互 | AUC 可能略降但延迟更低，用来估计复杂模块 ROI          | 若 B2 接近 B1，说明当前重模块贡献不足 |
+| B3: Symbiosis-full-log     | 不改模型，只增加诊断日志和分群评估                  | AUC 不变，但能解释误差来源                            | 为后续方案提供可比较诊断              |
+
+## 方案 A：当前组件消融
+
+### 假设
+
+当前 Symbiosis 的一部分模块已经有效，但贡献大小未知。先消融再重构，避免误删有效结构。
+
+### 实验
+
+- A1: 移除 `UserItemGraphBlock`。
+- A2: 移除 `FourierTimeEncoder`，只保留原始 time bucket embedding。
+- A3: 移除 `ContextExchangeBlock`。
+- A4: 移除 `_multi_scale_context`。
+- A5: 将 `UnifiedBlock._attend_sequences()` 的 domain mean 改为 gated domain weighting。
+- A6: 将 `num_blocks` 从 3 扫到 1、2、4。
+
+### 预期结果
+
+- 如果当前 Symbiosis 的融合思路有效，A1-A4 至少有一个会带来可复现 AUC 下降。
+- 如果多个消融几乎不影响 AUC，说明当前复杂度存在冗余，应优先简化而不是继续堆模块。
+- A5 若有效，预期 AUC 小幅提升，同时 domain 权重能解释哪些序列域有贡献。
+
+### 风险
+
+小样本上消融结论可能受随机性影响；正式结论需要固定 validation slice 和多 seed。
+
+## 方案 B：AUC-aware 训练目标
+
+### 假设
+
+AUC 只关心正负样本相对排序。BCE 隐式优化 AUC，但加入 batch 内 pairwise ranking loss 可能直接改善排序质量。
+
+### 设计
+
+保留 BCE 或 focal 作为主概率约束，增加 pairwise 项：
+
+```text
+loss = BCEWithLogits + lambda_pairwise * softplus(-(pos_logit - neg_logit) / temperature)
+```
+
+负样本先从同 batch 采样，再尝试 hard negative，即当前模型打分偏高的负样本。
+
+### 预期结果
+
+- AUC 可能提升 0.0005 到 0.003，尤其是在 hard negative 较多的 validation slice 上。
+- logloss 可能持平或略差，因为 pairwise loss 更关注排序而不是概率校准。
+- 若 lambda 过大，概率分布可能变尖，logloss 和稳定性变差。
+
+### 判定标准
+
+- AUC 提升必须超过 seed 波动，并且 logloss 不能明显劣化。
+- 若 AUC 升但 logloss 明显坏，需要只作为后期微调策略，而不是全程训练默认。
+
+## 方案 C：Candidate-conditioned 序列解码
+
+### 假设
+
+当前序列读取偏全局摘要，无法充分回答“这个候选 item 与用户哪段历史相关”。用 candidate token 和 conversion query 去读取各 domain 序列，可能更贴近 AUC 排序。
+
+### 设计
+
+每个 domain sequence 增加轻量解码器：
+
+```text
+query = candidate_context + conversion_query + user_context
+key/value = domain sequence tokens
+output = candidate_specific_domain_intent
+```
+
+输出保留 domain 维度，不再简单平均。最终由 domain gate 融合。
+
+### 预期结果
+
+- 若候选相关历史是主要信号，AUC 可能提升 0.001 到 0.004。
+- 对长序列用户、候选与历史强相关样本，分群 AUC 应更明显提升。
+- 推理延迟可能增加 10% 到 30%，需要用 top-k 或压缩记忆控制。
+
+### 风险
+
+- 若当前 item token 已经通过 UnifiedBlock 充分参与交互，新增 decoder 可能重复建模。
+- 若序列噪声大，candidate query 可能过拟合偶然共现。
+
+## 方案 D：Action conditioning 前移
+
+### 假设
+
+26 届离线任务接近点击样本中的转化预测。只在 head 里做 action conditioning 太晚，历史行为 token 应该显式携带 action 语义。
+
+### 设计
+
+如果 schema 中的历史序列包含 action 类字段，则加入：
+
+```text
+event_token = id_embedding + action_embedding + domain_embedding + time_embedding
+target_token = conversion_query
+```
+
+如果当前序列没有可用 action 字段，则先不做伪 action，避免泄漏或制造假信号。
+
+### 预期结果
+
+- 若历史 action 可用，AUC 可能提升 0.0005 到 0.002。
+- 转化稀疏或长序列用户上的提升可能更明显。
+- 若 action 与 label 构造强相关，必须检查是否存在 target leakage。
+
+### 判定标准
+
+只允许使用历史事件 action，不允许使用当前样本 label 或未来信息。任何无法证明无泄漏的结果不计入有效收益。
+
+## 方案 E：DeepSeek-V4 式多分辨率序列记忆
+
+### 假设
+
+长序列既需要近期细粒度行为，也需要远期压缩兴趣。将 CSA/HCA 思想改造成推荐序列记忆，可能在不显著增加延迟的情况下提升长历史利用率。
+
+### 设计
+
+每个 domain 构造三类 memory：
+
+```text
+recent memory      最近 N 个有效行为，保留原始 token
+compressed memory  每 m 个行为压缩成一个 block
+global memory      更大压缩率的长期摘要
+```
+
+candidate query 先选择 top-k compressed blocks，再与 recent memory 联合 attention。加入 learnable sink token，允许模型判断某个 domain 对当前候选无贡献。
+
+### 预期结果
+
+- 长序列分群 AUC 可能提升 0.001 到 0.003。
+- 全局 AUC 未必显著提升，因为短序列或弱序列用户占比可能稀释收益。
+- 推理延迟应低于 full sequence attention；若高于当前 Symbiosis 30% 以上，需要降级为 optional path。
+
+### 风险
+
+压缩 block 的学习可能不稳定；top-k 选择若不可微或实现复杂，第一版应采用 soft top-k 或固定窗口近似。
+
+## 方案 F：Attention sink / null evidence token
+
+### 假设
+
+并非每个候选 item 都能从每条历史序列中找到相关证据。强迫 attention 分配到历史 token 可能引入噪声。sink token 允许模型选择“不读取该 domain”。
+
+### 预期结果
+
+- 对噪声序列、弱相关 domain，AUC 和 logloss 可能小幅改善。
+- domain attention 分布应更稀疏，sink 权重可作为诊断信号。
+- 如果 sink 权重长期过高，说明序列模块没有被有效利用。
+
+### 判定标准
+
+只有在 AUC 不降且 sink 使用率与分群结果有合理相关性时保留。
+
+## 方案 G：Multi-lane constrained residual mixing
+
+### 假设
+
+Symbiosis 统一模块混合了 user、item、prompt、recent、long、domain 等多源信号。普通残差可能让某一类信号支配其他信号。借鉴 mHC 的稳定性思想，可用轻量 lane mixing 保护多源信息流。
+
+### 设计
+
+维护多个 lane：
+
+```text
+candidate lane
+user lane
+recent sequence lane
+long sequence lane
+domain interaction lane
+```
+
+每层使用非负归一化 mixing 权重，而不是无限制线性混合。第一版不实现完整 Sinkhorn，只做 row-stochastic gate。
+
+### 预期结果
+
+- 深层配置如 `num_blocks >= 4` 的训练稳定性可能改善。
+- AUC 提升未必来自浅层模型，主要看深度 scaling 是否更顺滑。
+- 参数和延迟增加应很小。
+
+### 风险
+
+约束过强可能限制表达能力；如果浅层模型效果不升，不应强行保留。
+
+## 方案 H：Semantic ID 表征增强
+
+### 假设
+
+Semantic ID 不应作为 26 届主输出，但可以作为 item/candidate 的离散语义补充，帮助长尾 item 和多模态/稀疏特征泛化。
+
+### 设计
+
+先离线生成 item semantic code，再作为 item 侧额外 token 或 embedding 输入。主输出仍是 probability。
+
+### 预期结果
+
+- 长尾 item、低频 item 分群 AUC 可能提升。
+- 全局 AUC 可能只有小幅变化，甚至因码本质量差而下降。
+- 离线码本生成成本较高，不应作为第一阶段改造。
+
+### 判定标准
+
+只有当低频 item 分群提升且整体 AUC 不降时进入正式方案。
+
+## 方案 I：优化器与 scaling 实验
+
+### 假设
+
+DeepSeek-V4 的 Muon 启发在于优化器分治，而不是盲目替换。推荐模型应保持稀疏 embedding 和 dense interaction block 分开优化。
+
+### 实验
+
+- 稀疏 embedding 继续用现有稀疏优化策略。
+- dense attention / mixer / projection 可试 AdamW vs Muon 类优化器。
+- norm、bias、gate、head 保守使用 AdamW。
+
+### 预期结果
+
+- 可能提升收敛速度，而不一定提升最终 AUC。
+- 若最终 AUC 相同但达到同等 AUC 的 step 更少，可作为 scaling law 方向证据。
+
+### 风险
+
+引入新优化器会增加环境与复现成本；只有在现有依赖和线上环境可控时才推进。
+
+## 实验矩阵
+
+| 阶段 | 实验                          | 目标                            | 成功标准                         | 退出条件                            |
+| ---- | ----------------------------- | ------------------------------- | -------------------------------- | ----------------------------------- |
+| S0   | B0/B1/B2/B3 基线              | 建立可信对照和诊断日志          | 指标稳定，能复现当前结果         | 基线自身不稳定，先修数据/训练流程   |
+| S1   | 当前组件消融                  | 判断现有 Symbiosis 哪些模块有效 | 找到至少一个可解释的正贡献模块   | 所有模块无贡献，转向简化版          |
+| S2   | AUC-aware loss                | 直接优化排序                    | AUC 提升且 logloss 可接受        | 多 seed 不稳定或校准明显恶化        |
+| S3   | Candidate-conditioned decoder | 强化候选相关历史读取            | 长序列/强历史分群 AUC 提升       | 延迟过高或全局 AUC 下降             |
+| S4   | Action 前移                   | 区分点击兴趣和转化意图          | 无泄漏前提下 AUC 提升            | schema 不支持历史 action 或疑似泄漏 |
+| S5   | 多分辨率 memory + sink        | 提升长序列效率和抗噪            | 长序列分群提升，延迟可控         | 复杂度高但收益不可复现              |
+| S6   | Lane mixing                   | 验证深层统一模块稳定性          | 深度 scaling 更平滑              | 浅层和深层均无收益                  |
+| S7   | Semantic ID                   | 增强候选表征                    | 长尾 item 分群提升               | 码本成本高且整体 AUC 不升           |
+| S8   | 优化器/scaling                | 研究计算效率和缩放规律          | 同等 AUC 所需 step 或 FLOPs 降低 | 环境不可复现或收益只出现在单 seed   |
+
+## 指标记录模板
+
+每个 run 至少记录：
+
+```text
+run_id
+git_commit
+experiment_package
+model_variant
+seed
+train_rows
+valid_rows
+num_parameters
+train_steps
+best_auc
+best_logloss
+final_auc
+final_logloss
+inference_latency_ms_per_batch
+positive_score_mean
+negative_score_mean
+score_margin_mean
+nan_count
+```
+
+推荐增加分群：
+
+- 序列长度桶：空、短、中、长、超长。
+- item 频率桶：低频、中频、高频。
+- 用户活跃度桶。
+- domain 缺失模式。
+- 最近行为时间桶。
+
+## 初始优先级
+
+第一阶段不要直接写一个巨大的 Symbiosis V2。建议顺序是：
+
+1. 先做 B3 诊断日志和 A 系列消融。
+2. 再做 B 系列 AUC-aware loss，因为改动小、贴指标。
+3. 再做 C 系列 candidate-conditioned decoder，这是最核心的架构假设。
+4. 然后根据 C 的收益决定是否进入 E/F 的压缩记忆和 sink token。
+5. G/H/I 作为第二阶段，服务深层 scaling、长尾泛化和训练效率。
+
+## 已启动工作
+
+- 2026-04-28：启动 B3 诊断日志第一步，在共享 metrics、PCVR trainer 和离线 evaluation 中加入 `score_diagnostics`，记录正负样本数量、正负样本平均分、平均分差、分数标准差、分位数和 invalid count。该改动不改变模型结构和训练目标，只增强后续消融实验的观测能力。
+- 2026-04-28：启动 A 系列组件消融基础设施，在共享训练 CLI、PCVR model builder 和 `config/symbiosis` 中加入可复现开关：`symbiosis_use_user_item_graph`、`symbiosis_use_fourier_time`、`symbiosis_use_context_exchange`、`symbiosis_use_multi_scale`、`symbiosis_use_domain_gate`。默认保持当前 Symbiosis 行为不变，后续可逐项关闭或启用 domain gate 做 A1-A5 实验。
+- 2026-04-28：完成首轮 L0 smoke。使用 `data/sample_1000_raw/demo_1000.parquet`、CPU、1 epoch、`batch_size=64`、`num_workers=0`、关闭 AMP/compile，跑通 B1 默认 Symbiosis 和 A1-A5 组件消融。由于该 parquet 只有单个 Row Group，训练和验证复用同 1000 行，结果只证明链路可运行、开关可落盘、诊断指标可读，不作为模型优劣结论。
+- 2026-04-28：将 AUC 解释性指标内聚到 `taac-evaluate single`。每次 eval/test 输出 AUC 时，会自动一起计算 `auc_ci`、`score_diagnostics` 和 `data_diagnostics`，避免为 AUC 表达力不足再维护独立分析 CLI。
+- 2026-04-28：对 B1/A1-A5 L0 smoke checkpoint 重新运行 `taac-evaluate single`，生成各 run 的 `validation_predictions.jsonl` 和增强后的 `evaluation.json`。六个 run 的 bootstrap 95% CI 全部与 B1 baseline 重叠，当前只说明评估链路可用，不说明任何组件优劣。
+
+| L0 run   | 开关                                  | 参数量      | valid AUC | logloss  | pos mean | neg mean | margin   | 用时 |
+| -------- | ------------------------------------- | ----------- | --------- | -------- | -------- | -------- | -------- | ---- |
+| B1 smoke | 默认 Symbiosis                        | 160,824,772 | 0.975586  | 0.227011 | 0.331396 | 0.068890 | 0.262506 | 43s  |
+| A1 smoke | `--no-symbiosis-use-user-item-graph`  | 160,376,260 | 0.978329  | 0.237869 | 0.295058 | 0.078232 | 0.216826 | 44s  |
+| A2 smoke | `--no-symbiosis-use-fourier-time`     | 160,824,772 | 0.976727  | 0.223777 | 0.337535 | 0.069100 | 0.268436 | 46s  |
+| A3 smoke | `--no-symbiosis-use-context-exchange` | 160,600,324 | 0.969795  | 0.231776 | 0.351352 | 0.088133 | 0.263219 | 24s  |
+| A4 smoke | `--no-symbiosis-use-multi-scale`      | 160,824,772 | 0.972732  | 0.231006 | 0.328535 | 0.068924 | 0.259612 | 68s  |
+| A5 smoke | `--symbiosis-use-domain-gate`         | 160,824,772 | 0.976064  | 0.228063 | 0.329349 | 0.068870 | 0.260479 | 71s  |
+
+这些 L0 数字有两个直接用途：第一，确认消融配置能进入 `train_config.json` 并完成 checkpoint 保存；第二，暴露初步工程成本，例如 A3 明显更快、A5 在 CPU smoke 上更慢。补跑增强后的 `taac-evaluate single` 后，所有 run 的 95% CI 都与 B1 baseline 重叠，因此 AUC 差异不解读。下一步必须换成 `data_diagnostics` 判定为 L1-ready 的固定验证切片，再做正式比较。
+
+## 当前结论
+
+当前 Symbiosis 有价值，但价值还没有被严格拆解。它已经提供了一个融合 user、item、序列、时间和 action prompt 的统一实验平台。下一步不是否定它，而是把它变成一套可被证伪的实验体系：哪些模块贡献 AUC，哪些模块只是复杂，哪些 DeepSeek-V4 或 TAAC 2025 启发能在 2026 AUC 契约下真正成立，都必须由实验结果决定。

--- a/src/taac2026/application/reporting/cli.py
+++ b/src/taac2026/application/reporting/cli.py
@@ -102,6 +102,8 @@ def _build_profile_components(
     experiment = load_experiment_package(experiment_path)
     if experiment.package_dir is None:
         raise ValueError(f"experiment {experiment_path!r} does not declare package_dir")
+    if experiment.train_defaults is None:
+        raise ValueError(f"experiment {experiment_path!r} does not declare typed train_defaults")
 
     model_module = _load_model_module(experiment_path)
     forwarded_args = [
@@ -115,10 +117,9 @@ def _build_profile_components(
         str(run_dir / "logs"),
         "--tf_events_dir",
         str(run_dir / "tensorboard"),
-        *experiment.default_train_args,
         *override_args,
     ]
-    parsed_args = parse_pcvr_train_args(forwarded_args, package_dir=experiment.package_dir)
+    parsed_args = parse_pcvr_train_args(forwarded_args, package_dir=experiment.package_dir, defaults=experiment.train_defaults)
     config = vars(parsed_args).copy()
     seq_max_lens = parse_seq_max_lens(str(parsed_args.seq_max_lens))
     train_loader, _valid_loader, dataset = pcvr_data.get_pcvr_data(

--- a/src/taac2026/domain/experiment.py
+++ b/src/taac2026/domain/experiment.py
@@ -22,7 +22,7 @@ class ExperimentSpec:
     train_fn: TrainFn | None = None
     evaluate_fn: EvalFn | None = None
     infer_fn: InferFn | None = None
-    default_train_args: tuple[str, ...] = ()
+    train_defaults: Any | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
 
     def train(self, request: TrainRequest) -> Mapping[str, Any] | None:

--- a/src/taac2026/domain/metrics.py
+++ b/src/taac2026/domain/metrics.py
@@ -71,6 +71,97 @@ def binary_logloss(labels: np.ndarray, probabilities: np.ndarray) -> float:
     return float(loss.mean())
 
 
+def binary_score_diagnostics(labels: np.ndarray, scores: np.ndarray) -> dict[str, float | int]:
+    labels_array = np.asarray(labels, dtype=np.float64).reshape(-1)
+    scores_array = np.asarray(scores, dtype=np.float64).reshape(-1)
+    valid_mask = np.isfinite(labels_array) & np.isfinite(scores_array)
+    labels_array = labels_array[valid_mask]
+    scores_array = scores_array[valid_mask]
+    sample_count = int(labels_array.size)
+    positive_scores = scores_array[labels_array > 0.5]
+    negative_scores = scores_array[labels_array <= 0.5]
+    positive_count = int(positive_scores.size)
+    negative_count = int(negative_scores.size)
+    positive_mean = safe_mean(positive_scores)
+    negative_mean = safe_mean(negative_scores)
+    return {
+        "sample_count": sample_count,
+        "positive_count": positive_count,
+        "negative_count": negative_count,
+        "invalid_count": int(valid_mask.size - valid_mask.sum()),
+        "positive_rate": float(positive_count / sample_count) if sample_count else 0.0,
+        "score_mean": safe_mean(scores_array),
+        "score_std": float(np.std(scores_array)) if sample_count else 0.0,
+        "positive_score_mean": positive_mean,
+        "negative_score_mean": negative_mean,
+        "score_margin_mean": positive_mean - negative_mean if positive_count and negative_count else 0.0,
+        "positive_score_p10": percentile(positive_scores, 10),
+        "positive_score_p50": percentile(positive_scores, 50),
+        "positive_score_p90": percentile(positive_scores, 90),
+        "negative_score_p10": percentile(negative_scores, 10),
+        "negative_score_p50": percentile(negative_scores, 50),
+        "negative_score_p90": percentile(negative_scores, 90),
+    }
+
+
+def binary_auc_bootstrap_ci(
+    labels: np.ndarray,
+    scores: np.ndarray,
+    *,
+    samples: int = 200,
+    seed: int = 42,
+    confidence: float = 0.95,
+    max_resample_size: int = 50_000,
+) -> dict[str, float | int]:
+    labels_array = np.asarray(labels, dtype=np.float64).reshape(-1)
+    scores_array = np.asarray(scores, dtype=np.float64).reshape(-1)
+    valid_mask = np.isfinite(labels_array) & np.isfinite(scores_array)
+    labels_array = labels_array[valid_mask]
+    scores_array = scores_array[valid_mask]
+    auc = binary_auc(labels_array, scores_array)
+    positive_indices = np.flatnonzero(labels_array > 0.5)
+    negative_indices = np.flatnonzero(labels_array <= 0.5)
+    positive_count = int(positive_indices.size)
+    negative_count = int(negative_indices.size)
+    if samples <= 0 or positive_count == 0 or negative_count == 0:
+        return {
+            "samples": 0,
+            "confidence": float(confidence),
+            "low": auc,
+            "high": auc,
+            "std": 0.0,
+            "positive_resample_count": positive_count,
+            "negative_resample_count": negative_count,
+        }
+
+    total_count = positive_count + negative_count
+    if max_resample_size > 0 and total_count > max_resample_size:
+        positive_draw_count = max(1, round(max_resample_size * positive_count / total_count))
+        negative_draw_count = max(1, max_resample_size - positive_draw_count)
+    else:
+        positive_draw_count = positive_count
+        negative_draw_count = negative_count
+
+    generator = np.random.default_rng(seed)
+    values = np.empty(samples, dtype=np.float64)
+    for sample_index in range(samples):
+        sampled_positive = generator.choice(positive_indices, size=positive_draw_count, replace=True)
+        sampled_negative = generator.choice(negative_indices, size=negative_draw_count, replace=True)
+        sampled_indices = np.concatenate([sampled_positive, sampled_negative])
+        values[sample_index] = binary_auc(labels_array[sampled_indices], scores_array[sampled_indices])
+
+    tail = (1.0 - confidence) / 2.0
+    return {
+        "samples": int(samples),
+        "confidence": float(confidence),
+        "low": float(np.percentile(values, tail * 100.0)),
+        "high": float(np.percentile(values, (1.0 - tail) * 100.0)),
+        "std": float(np.std(values)),
+        "positive_resample_count": int(positive_draw_count),
+        "negative_resample_count": int(negative_draw_count),
+    }
+
+
 def group_auc(labels: np.ndarray, scores: np.ndarray, groups: np.ndarray) -> dict[str, float]:
     labels_array = np.asarray(labels).reshape(-1)
     scores_array = np.asarray(scores).reshape(-1)
@@ -98,6 +189,9 @@ def compute_classification_metrics(
     labels: np.ndarray,
     scores: np.ndarray,
     groups: np.ndarray | None = None,
+    *,
+    auc_bootstrap_samples: int = 200,
+    auc_bootstrap_seed: int = 42,
 ) -> dict[str, object]:
     labels_array = np.asarray(labels, dtype=np.float64).reshape(-1)
     score_array = np.asarray(scores, dtype=np.float64).reshape(-1)
@@ -111,8 +205,15 @@ def compute_classification_metrics(
     brier = float(np.mean((probabilities - labels_array) ** 2)) if labels_array.size else 0.0
     return {
         "auc": binary_auc(labels_array, probabilities),
+        "auc_ci": binary_auc_bootstrap_ci(
+            labels_array,
+            probabilities,
+            samples=auc_bootstrap_samples,
+            seed=auc_bootstrap_seed,
+        ),
         "logloss": binary_logloss(labels_array, probabilities),
         "brier": brier,
         "gauc": group_auc(labels_array, probabilities, groups_array),
+        "score_diagnostics": binary_score_diagnostics(labels_array, probabilities),
         "sample_count": int(labels_array.size),
     }

--- a/src/taac2026/infrastructure/experiments/loader.py
+++ b/src/taac2026/infrastructure/experiments/loader.py
@@ -23,7 +23,7 @@ def _coerce_experiment(value: object, source: str) -> ExperimentSpec:
             train_fn=value.train,
             evaluate_fn=value.evaluate,
             infer_fn=value.infer,
-            default_train_args=tuple(getattr(value, "default_train_args", ())),
+            train_defaults=getattr(value, "train_defaults", None),
             metadata=dict(getattr(value, "metadata", {})),
         )
     raise TypeError(f"EXPERIMENT in {source} is not a supported experiment object")

--- a/src/taac2026/infrastructure/pcvr/config.py
+++ b/src/taac2026/infrastructure/pcvr/config.py
@@ -1,0 +1,255 @@
+"""Typed configuration objects for PCVR experiment packages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from taac2026.infrastructure.training.runtime import (
+    BinaryClassificationLossConfig,
+    RuntimeExecutionConfig,
+)
+
+
+SeqEncoderType = Literal["swiglu", "transformer", "longer"]
+RankMixerMode = Literal["full", "ffn_only", "none"]
+NSTokenizerType = Literal["group", "rankmixer"]
+PCVRSeqWindowMode = Literal["tail", "random_tail", "rolling"]
+PCVRDataCacheMode = Literal["none", "memory"]
+
+
+@dataclass(frozen=True, slots=True)
+class PCVRDataConfig:
+    batch_size: int = 256
+    num_workers: int = 16
+    buffer_batches: int = 20
+    train_ratio: float = 1.0
+    valid_ratio: float = 0.1
+    eval_every_n_steps: int = 0
+    seq_max_lens: str = "seq_a:256,seq_b:256,seq_c:512,seq_d:512"
+
+
+@dataclass(frozen=True, slots=True)
+class PCVRSequenceCropConfig:
+    name: Literal["sequence_crop"] = "sequence_crop"
+    enabled: bool = True
+    views_per_row: int = 1
+    seq_window_mode: PCVRSeqWindowMode = "tail"
+    seq_window_min_len: int = 1
+
+
+@dataclass(frozen=True, slots=True)
+class PCVRFeatureMaskConfig:
+    name: Literal["feature_mask"] = "feature_mask"
+    enabled: bool = True
+    probability: float = 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class PCVRDomainDropoutConfig:
+    name: Literal["domain_dropout"] = "domain_dropout"
+    enabled: bool = True
+    probability: float = 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class PCVRDataCacheConfig:
+    mode: PCVRDataCacheMode = "none"
+    max_batches: int = 0
+
+    @property
+    def enabled(self) -> bool:
+        return self.mode == "memory"
+
+
+PCVRDataTransformConfig = (
+    PCVRSequenceCropConfig | PCVRFeatureMaskConfig | PCVRDomainDropoutConfig
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PCVRDataPipelineConfig:
+    cache: PCVRDataCacheConfig = field(default_factory=PCVRDataCacheConfig)
+    transforms: tuple[PCVRDataTransformConfig, ...] = ()
+    seed: int | None = None
+    strict_time_filter: bool = True
+
+    @property
+    def enabled(self) -> bool:
+        return any(transform.enabled for transform in self.transforms)
+
+    @property
+    def transform_names(self) -> tuple[str, ...]:
+        return tuple(
+            transform.name for transform in self.transforms if transform.enabled
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "cache": {
+                "mode": self.cache.mode,
+                "max_batches": self.cache.max_batches,
+            },
+            "seed": self.seed,
+            "strict_time_filter": self.strict_time_filter,
+            "transforms": [
+                _data_transform_config_to_dict(transform)
+                for transform in self.transforms
+            ],
+        }
+
+    def to_flat_dict(self) -> dict[str, Any]:
+        return {
+            "data_pipeline": self.to_dict(),
+        }
+
+
+def _data_transform_config_to_dict(
+    transform: PCVRDataTransformConfig,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "name": transform.name,
+        "enabled": transform.enabled,
+    }
+    if isinstance(transform, PCVRSequenceCropConfig):
+        payload.update(
+            {
+                "views_per_row": transform.views_per_row,
+                "seq_window_mode": transform.seq_window_mode,
+                "seq_window_min_len": transform.seq_window_min_len,
+            }
+        )
+    elif isinstance(transform, (PCVRFeatureMaskConfig, PCVRDomainDropoutConfig)):
+        payload["probability"] = transform.probability
+    return payload
+
+
+@dataclass(frozen=True, slots=True)
+class PCVROptimizerConfig:
+    lr: float = 1e-4
+    num_epochs: int = 999
+    patience: int = 5
+    seed: int = 42
+    device: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PCVRSparseOptimizerConfig:
+    sparse_lr: float = 0.05
+    sparse_weight_decay: float = 0.0
+    reinit_sparse_after_epoch: int = 1
+    reinit_cardinality_threshold: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class PCVRModelConfig:
+    d_model: int = 64
+    emb_dim: int = 64
+    num_queries: int = 1
+    num_blocks: int = 2
+    num_heads: int = 4
+    seq_encoder_type: SeqEncoderType = "transformer"
+    hidden_mult: int = 4
+    dropout_rate: float = 0.01
+    seq_top_k: int = 50
+    seq_causal: bool = False
+    action_num: int = 1
+    use_time_buckets: bool = True
+    rank_mixer_mode: RankMixerMode = "full"
+    use_rope: bool = False
+    rope_base: float = 10000.0
+    emb_skip_threshold: int = 0
+    seq_id_threshold: int = 10000
+
+
+@dataclass(frozen=True, slots=True)
+class PCVRNSConfig:
+    groups_json: str = "ns_groups.json"
+    tokenizer_type: NSTokenizerType = "rankmixer"
+    user_tokens: int = 0
+    item_tokens: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class PCVRSymbiosisConfig:
+    use_user_item_graph: bool = True
+    use_fourier_time: bool = True
+    use_context_exchange: bool = True
+    use_multi_scale: bool = True
+    use_domain_gate: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class PCVRTrainConfig:
+    data: PCVRDataConfig = field(default_factory=PCVRDataConfig)
+    data_pipeline: PCVRDataPipelineConfig = field(
+        default_factory=PCVRDataPipelineConfig
+    )
+    optimizer: PCVROptimizerConfig = field(default_factory=PCVROptimizerConfig)
+    runtime: RuntimeExecutionConfig = field(default_factory=RuntimeExecutionConfig)
+    loss: BinaryClassificationLossConfig = field(
+        default_factory=BinaryClassificationLossConfig
+    )
+    sparse_optimizer: PCVRSparseOptimizerConfig = field(
+        default_factory=PCVRSparseOptimizerConfig
+    )
+    model: PCVRModelConfig = field(default_factory=PCVRModelConfig)
+    ns: PCVRNSConfig = field(default_factory=PCVRNSConfig)
+    symbiosis: PCVRSymbiosisConfig = field(default_factory=PCVRSymbiosisConfig)
+
+    def to_flat_dict(self) -> dict[str, Any]:
+        return {
+            "batch_size": self.data.batch_size,
+            "num_workers": self.data.num_workers,
+            "buffer_batches": self.data.buffer_batches,
+            "train_ratio": self.data.train_ratio,
+            "valid_ratio": self.data.valid_ratio,
+            "eval_every_n_steps": self.data.eval_every_n_steps,
+            "seq_max_lens": self.data.seq_max_lens,
+            **self.data_pipeline.to_flat_dict(),
+            "lr": self.optimizer.lr,
+            "num_epochs": self.optimizer.num_epochs,
+            "patience": self.optimizer.patience,
+            "seed": self.optimizer.seed,
+            "device": self.optimizer.device,
+            "amp": self.runtime.amp,
+            "amp_dtype": self.runtime.amp_dtype,
+            "compile": self.runtime.compile,
+            "loss_type": self.loss.loss_type,
+            "focal_alpha": self.loss.focal_alpha,
+            "focal_gamma": self.loss.focal_gamma,
+            "sparse_lr": self.sparse_optimizer.sparse_lr,
+            "sparse_weight_decay": self.sparse_optimizer.sparse_weight_decay,
+            "reinit_sparse_after_epoch": self.sparse_optimizer.reinit_sparse_after_epoch,
+            "reinit_cardinality_threshold": self.sparse_optimizer.reinit_cardinality_threshold,
+            "d_model": self.model.d_model,
+            "emb_dim": self.model.emb_dim,
+            "num_queries": self.model.num_queries,
+            "num_blocks": self.model.num_blocks,
+            "num_heads": self.model.num_heads,
+            "seq_encoder_type": self.model.seq_encoder_type,
+            "hidden_mult": self.model.hidden_mult,
+            "dropout_rate": self.model.dropout_rate,
+            "seq_top_k": self.model.seq_top_k,
+            "seq_causal": self.model.seq_causal,
+            "action_num": self.model.action_num,
+            "use_time_buckets": self.model.use_time_buckets,
+            "rank_mixer_mode": self.model.rank_mixer_mode,
+            "use_rope": self.model.use_rope,
+            "rope_base": self.model.rope_base,
+            "emb_skip_threshold": self.model.emb_skip_threshold,
+            "seq_id_threshold": self.model.seq_id_threshold,
+            "ns_groups_json": self.ns.groups_json,
+            "ns_tokenizer_type": self.ns.tokenizer_type,
+            "user_ns_tokens": self.ns.user_tokens,
+            "item_ns_tokens": self.ns.item_tokens,
+            "symbiosis_use_user_item_graph": self.symbiosis.use_user_item_graph,
+            "symbiosis_use_fourier_time": self.symbiosis.use_fourier_time,
+            "symbiosis_use_context_exchange": self.symbiosis.use_context_exchange,
+            "symbiosis_use_multi_scale": self.symbiosis.use_multi_scale,
+            "symbiosis_use_domain_gate": self.symbiosis.use_domain_gate,
+        }
+
+
+DEFAULT_PCVR_TRAIN_CONFIG = PCVRTrainConfig()
+REQUIRED_PCVR_TRAIN_CONFIG_KEYS = frozenset(DEFAULT_PCVR_TRAIN_CONFIG.to_flat_dict())

--- a/src/taac2026/infrastructure/pcvr/data.py
+++ b/src/taac2026/infrastructure/pcvr/data.py
@@ -15,7 +15,9 @@ import gc
 import json
 import logging
 import random
-from collections.abc import Iterator
+import zlib
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -26,6 +28,16 @@ import torch
 import torch.multiprocessing
 from numpy.typing import NDArray
 from torch.utils.data import IterableDataset, DataLoader
+
+from taac2026.infrastructure.pcvr.config import PCVRDataPipelineConfig
+from taac2026.infrastructure.pcvr.data_pipeline import (
+    PCVRBatchTransform,
+    PCVRDataPipeline,
+    PCVRMemoryBatchCache,
+    PCVRShuffleBuffer,
+    build_pcvr_batch_transforms,
+    stable_pcvr_batch_seed_from_path_crc,
+)
 
 
 # ─────────────────────────── Feature Schema ──────────────────────────────────
@@ -72,18 +84,18 @@ class FeatureSchema:
     def to_dict(self) -> dict[str, Any]:
         """Serialize to a plain dict (for JSON dumping)."""
         return {
-            'entries': self.entries,
-            'total_dim': self.total_dim,
+            "entries": self.entries,
+            "total_dim": self.total_dim,
         }
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> 'FeatureSchema':
+    def from_dict(cls, d: dict[str, Any]) -> "FeatureSchema":
         """Reconstruct a :class:`FeatureSchema` from its dict form."""
         schema = cls()
-        for fid, offset, length in d['entries']:
+        for fid, offset, length in d["entries"]:
             schema.entries.append((fid, offset, length))
             schema._fid_to_entry[fid] = (offset, length)
-        schema.total_dim = d['total_dim']
+        schema.total_dim = d["total_dim"]
         return schema
 
     def __repr__(self) -> str:
@@ -93,23 +105,80 @@ class FeatureSchema:
         lines.append("])")
         return "\n".join(lines)
 
+
 # Use filesystem-based tensor sharing (instead of /dev/shm) to avoid running
 # out of shared memory when many DataLoader workers are active.
-torch.multiprocessing.set_sharing_strategy('file_system')
+torch.multiprocessing.set_sharing_strategy("file_system")
 
 # Time-delta bucket boundaries (64 edges -> 65 buckets: 0=padding, 1..64).
-BUCKET_BOUNDARIES = np.array([
-    5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60,
-    120, 180, 240, 300, 360, 420, 480, 540, 600,
-    900, 1200, 1500, 1800, 2100, 2400, 2700, 3000, 3300, 3600,
-    5400, 7200, 9000, 10800, 12600, 14400, 16200, 18000, 19800, 21600,
-    32400, 43200, 54000, 64800, 75600, 86400,
-    172800, 259200, 345600, 432000, 518400, 604800,
-    1123200, 1641600, 2160000, 2592000,
-    4320000, 6048000, 7776000,
-    11664000, 15552000,
-    31536000,
-], dtype=np.int64)
+BUCKET_BOUNDARIES = np.array(
+    [
+        5,
+        10,
+        15,
+        20,
+        25,
+        30,
+        35,
+        40,
+        45,
+        50,
+        55,
+        60,
+        120,
+        180,
+        240,
+        300,
+        360,
+        420,
+        480,
+        540,
+        600,
+        900,
+        1200,
+        1500,
+        1800,
+        2100,
+        2400,
+        2700,
+        3000,
+        3300,
+        3600,
+        5400,
+        7200,
+        9000,
+        10800,
+        12600,
+        14400,
+        16200,
+        18000,
+        19800,
+        21600,
+        32400,
+        43200,
+        54000,
+        64800,
+        75600,
+        86400,
+        172800,
+        259200,
+        345600,
+        432000,
+        518400,
+        604800,
+        1123200,
+        1641600,
+        2160000,
+        2592000,
+        4320000,
+        6048000,
+        7776000,
+        11664000,
+        15552000,
+        31536000,
+    ],
+    dtype=np.int64,
+)
 
 # Total number of time-bucket embedding slots (= number of boundaries + 1, with
 # padding=0 included).
@@ -121,6 +190,99 @@ BUCKET_BOUNDARIES = np.array([
 # That is why ``train.py`` / ``infer.py`` only expose the boolean flag
 # ``--use_time_buckets`` and derive the concrete bucket count from here.
 NUM_TIME_BUCKETS = len(BUCKET_BOUNDARIES) + 1
+
+
+@dataclass(frozen=True, slots=True)
+class PCVRRowGroupSplitPlan:
+    total_row_groups: int
+    train_row_groups: int
+    valid_row_groups: int
+    train_row_group_range: tuple[int, int]
+    valid_row_group_range: tuple[int, int]
+    train_rows: int
+    valid_rows: int
+    reuse_train_for_valid: bool
+
+    @property
+    def is_disjoint(self) -> bool:
+        return (
+            not self.reuse_train_for_valid
+            and self.train_row_group_range[1] <= self.valid_row_group_range[0]
+        )
+
+    @property
+    def is_l1_ready(self) -> bool:
+        return (
+            self.is_disjoint
+            and self.train_rows > 0
+            and self.valid_rows > 0
+            and self.train_row_groups > 0
+            and self.valid_row_groups > 0
+        )
+
+
+def collect_pcvr_row_groups(data_dir: str | Path) -> list[tuple[str, int, int]]:
+    data_path = Path(data_dir).expanduser()
+    if data_path.is_dir():
+        pq_files = sorted(str(path) for path in data_path.glob("*.parquet"))
+    else:
+        pq_files = [str(data_path)]
+    if not pq_files:
+        raise FileNotFoundError(f"No .parquet files found at {data_dir}")
+
+    rg_info: list[tuple[str, int, int]] = []
+    for f in pq_files:
+        pf = pq.ParquetFile(f)
+        for i in range(pf.metadata.num_row_groups):
+            rg_info.append((f, i, pf.metadata.row_group(i).num_rows))
+    return rg_info
+
+
+def plan_pcvr_row_group_split(
+    rg_info: list[tuple[str, int, int]],
+    *,
+    valid_ratio: float = 0.1,
+    train_ratio: float = 1.0,
+) -> PCVRRowGroupSplitPlan:
+    total_rgs = len(rg_info)
+    if total_rgs == 0:
+        raise ValueError("at least one Row Group is required")
+
+    n_valid_rgs = max(1, int(total_rgs * valid_ratio))
+    n_train_rgs = total_rgs - n_valid_rgs
+    reuse_train_for_valid = False
+
+    if total_rgs == 1:
+        n_train_rgs = 1
+        n_valid_rgs = 1
+        reuse_train_for_valid = True
+    elif n_train_rgs == 0:
+        n_train_rgs = total_rgs - 1
+        n_valid_rgs = 1
+
+    if train_ratio < 1.0 and not reuse_train_for_valid:
+        n_train_rgs = max(1, int(n_train_rgs * train_ratio))
+
+    train_row_group_range = (0, n_train_rgs)
+    valid_row_group_range = (
+        (0, total_rgs) if reuse_train_for_valid else (n_train_rgs, total_rgs)
+    )
+    train_rows = sum(
+        r[2] for r in rg_info[train_row_group_range[0] : train_row_group_range[1]]
+    )
+    valid_rows = sum(
+        r[2] for r in rg_info[valid_row_group_range[0] : valid_row_group_range[1]]
+    )
+    return PCVRRowGroupSplitPlan(
+        total_row_groups=total_rgs,
+        train_row_groups=n_train_rgs,
+        valid_row_groups=n_valid_rgs,
+        train_row_group_range=train_row_group_range,
+        valid_row_group_range=valid_row_group_range,
+        train_rows=train_rows,
+        valid_rows=valid_rows,
+        reuse_train_for_valid=reuse_train_for_valid,
+    )
 
 
 class PCVRParquetDataset(IterableDataset):
@@ -144,6 +306,8 @@ class PCVRParquetDataset(IterableDataset):
         row_group_range: tuple[int, int] | None = None,
         clip_vocab: bool = True,
         is_training: bool = True,
+        data_pipeline_config: PCVRDataPipelineConfig | None = None,
+        transforms: Sequence[PCVRBatchTransform] | None = None,
     ) -> None:
         """
         Args:
@@ -161,13 +325,16 @@ class PCVRParquetDataset(IterableDataset):
             clip_vocab: if True, clip out-of-bound ids to 0; if False, raise.
             is_training: if True, derive ``label`` from ``label_type == 2``;
                 if False, return an all-zeros label column.
+            data_pipeline_config: optional cache and transform pipeline settings.
+            transforms: optional additional batch transforms applied after
+                conversion and before shuffle buffering.
         """
         super().__init__()
 
         # Accept either a directory or a single file path.
         parquet_root = Path(parquet_path).expanduser()
         if parquet_root.is_dir():
-            files = sorted(parquet_root.glob('*.parquet'))
+            files = sorted(parquet_root.glob("*.parquet"))
             if not files:
                 raise FileNotFoundError(f"No .parquet files in {parquet_path}")
             self._parquet_files = [str(path) for path in files]
@@ -179,6 +346,12 @@ class PCVRParquetDataset(IterableDataset):
         self.buffer_batches = buffer_batches
         self.clip_vocab = clip_vocab
         self.is_training = is_training
+        self.data_pipeline_config = data_pipeline_config or PCVRDataPipelineConfig()
+        self._strict_time_filter = bool(
+            self.is_training
+            and self.data_pipeline_config.enabled
+            and self.data_pipeline_config.strict_time_filter
+        )
         # Out-of-bound statistics:
         #   {(group, col_idx): {'count': N, 'max': M, 'min_oob': M, 'vocab': V}}
         self._oob_stats: dict[tuple[str, int], dict[str, int]] = {}
@@ -206,9 +379,15 @@ class PCVRParquetDataset(IterableDataset):
 
         # ---- Pre-allocate numpy buffers ----
         B = batch_size
-        self._buf_user_int = np.zeros((B, self.user_int_schema.total_dim), dtype=np.int64)
-        self._buf_item_int = np.zeros((B, self.item_int_schema.total_dim), dtype=np.int64)
-        self._buf_user_dense = np.zeros((B, self.user_dense_schema.total_dim), dtype=np.float32)
+        self._buf_user_int = np.zeros(
+            (B, self.user_int_schema.total_dim), dtype=np.int64
+        )
+        self._buf_item_int = np.zeros(
+            (B, self.item_int_schema.total_dim), dtype=np.int64
+        )
+        self._buf_user_dense = np.zeros(
+            (B, self.user_dense_schema.total_dim), dtype=np.float32
+        )
         self._buf_seq = {}
         self._buf_seq_tb = {}
         self._buf_seq_lens = {}
@@ -223,21 +402,21 @@ class PCVRParquetDataset(IterableDataset):
         self._user_int_plan = []  # [(col_idx, dim, offset, vocab_size), ...]
         offset = 0
         for fid, vs, dim in self._user_int_cols:
-            ci = self._col_idx.get(f'user_int_feats_{fid}')
+            ci = self._col_idx.get(f"user_int_feats_{fid}")
             self._user_int_plan.append((ci, dim, offset, vs))
             offset += dim
 
         self._item_int_plan = []
         offset = 0
         for fid, vs, dim in self._item_int_cols:
-            ci = self._col_idx.get(f'item_int_feats_{fid}')
+            ci = self._col_idx.get(f"item_int_feats_{fid}")
             self._item_int_plan.append((ci, dim, offset, vs))
             offset += dim
 
         self._user_dense_plan = []
         offset = 0
         for fid, dim in self._user_dense_cols:
-            ci = self._col_idx.get(f'user_dense_feats_{fid}')
+            ci = self._col_idx.get(f"user_dense_feats_{fid}")
             self._user_dense_plan.append((ci, dim, offset))
             offset += dim
 
@@ -249,24 +428,37 @@ class PCVRParquetDataset(IterableDataset):
             ts_fid = self.ts_fids[domain]
             side_plan = []
             for slot, fid in enumerate(sideinfo_fids):
-                ci = self._col_idx.get(f'{prefix}_{fid}')
+                ci = self._col_idx.get(f"{prefix}_{fid}")
                 vs = self.seq_vocab_sizes[domain][fid]
                 side_plan.append((ci, slot, vs))
-            ts_ci = self._col_idx.get(f'{prefix}_{ts_fid}') if ts_fid is not None else None
+            ts_ci = (
+                self._col_idx.get(f"{prefix}_{ts_fid}") if ts_fid is not None else None
+            )
             self._seq_plan[domain] = (side_plan, ts_ci)
 
         logging.info(
             f"PCVRParquetDataset: {self.num_rows} rows from "
             f"{len(self._parquet_files)} file(s), batch_size={batch_size}, "
-            f"buffer_batches={buffer_batches}, shuffle={shuffle}")
+            f"buffer_batches={buffer_batches}, shuffle={shuffle}"
+        )
+
+        pipeline_transforms = list(transforms or [])
+        if self.is_training:
+            pipeline_transforms.extend(
+                build_pcvr_batch_transforms(self.data_pipeline_config)
+            )
+        self.pipeline = PCVRDataPipeline(
+            cache=PCVRMemoryBatchCache.from_config(self.data_pipeline_config.cache),
+            transforms=tuple(pipeline_transforms),
+        )
 
     def _load_schema(self, schema_path: str, seq_max_lens: dict[str, int]) -> None:
         """Populate per-group schema information from ``schema_path``."""
-        with Path(schema_path).open(encoding='utf-8') as f:
+        with Path(schema_path).open(encoding="utf-8") as f:
             raw = json.load(f)
 
         # ---- user_int: [[fid, vocab_size, dim], ...] ----
-        self._user_int_cols: list[list[int]] = raw['user_int']
+        self._user_int_cols: list[list[int]] = raw["user_int"]
         self.user_int_schema: FeatureSchema = FeatureSchema()
         self.user_int_vocab_sizes: list[int] = []
         for fid, vs, dim in self._user_int_cols:
@@ -274,7 +466,7 @@ class PCVRParquetDataset(IterableDataset):
             self.user_int_vocab_sizes.extend([vs] * dim)
 
         # ---- item_int ----
-        self._item_int_cols: list[list[int]] = raw['item_int']
+        self._item_int_cols: list[list[int]] = raw["item_int"]
         self.item_int_schema: FeatureSchema = FeatureSchema()
         self.item_int_vocab_sizes: list[int] = []
         for fid, vs, dim in self._item_int_cols:
@@ -282,7 +474,7 @@ class PCVRParquetDataset(IterableDataset):
             self.item_int_vocab_sizes.extend([vs] * dim)
 
         # ---- user_dense: [[fid, dim], ...] ----
-        self._user_dense_cols: list[list[int]] = raw['user_dense']
+        self._user_dense_cols: list[list[int]] = raw["user_dense"]
         self.user_dense_schema: FeatureSchema = FeatureSchema()
         for fid, dim in self._user_dense_cols:
             self.user_dense_schema.add(fid, dim)
@@ -291,7 +483,7 @@ class PCVRParquetDataset(IterableDataset):
         self.item_dense_schema: FeatureSchema = FeatureSchema()
 
         # ---- sequence domains ----
-        self._seq_cfg: dict[str, dict[str, Any]] = raw['seq']
+        self._seq_cfg: dict[str, dict[str, Any]] = raw["seq"]
         self.seq_domains: list[str] = sorted(self._seq_cfg.keys())
         self.seq_feature_ids: dict[str, list[int]] = {}
         self.seq_vocab_sizes: dict[str, dict[int, int]] = {}
@@ -303,13 +495,13 @@ class PCVRParquetDataset(IterableDataset):
 
         for domain in self.seq_domains:
             cfg = self._seq_cfg[domain]
-            self._seq_prefix[domain] = cfg['prefix']
-            ts_fid = cfg['ts_fid']
+            self._seq_prefix[domain] = cfg["prefix"]
+            ts_fid = cfg["ts_fid"]
             self.ts_fids[domain] = ts_fid
 
-            all_fids = [fid for fid, vs in cfg['features']]
+            all_fids = [fid for fid, vs in cfg["features"]]
             self.seq_feature_ids[domain] = all_fids
-            self.seq_vocab_sizes[domain] = {fid: vs for fid, vs in cfg['features']}
+            self.seq_vocab_sizes[domain] = {fid: vs for fid, vs in cfg["features"]}
 
             sideinfo = [fid for fid in all_fids if fid != ts_fid]
             self.sideinfo_fids[domain] = sideinfo
@@ -322,57 +514,87 @@ class PCVRParquetDataset(IterableDataset):
 
     def __len__(self) -> int:
         # Ceiling per Row Group; this is an upper bound on the true batch count.
-        return sum((n + self.batch_size - 1) // self.batch_size
-                   for _, _, n in self._rg_list)
+        return sum(
+            (n + self.batch_size - 1) // self.batch_size for _, _, n in self._rg_list
+        )
 
     def __iter__(self) -> Iterator[dict[str, Any]]:
         worker_info = torch.utils.data.get_worker_info()
+        worker_id = worker_info.id if worker_info is not None else 0
         rg_list = self._rg_list
         if worker_info is not None and worker_info.num_workers > 1:
-            rg_list = [rg for i, rg in enumerate(rg_list)
-                       if i % worker_info.num_workers == worker_info.id]
+            rg_list = [
+                rg
+                for i, rg in enumerate(rg_list)
+                if i % worker_info.num_workers == worker_info.id
+            ]
 
-        buffer: list[dict[str, Any]] = []
+        shuffle_buffer = PCVRShuffleBuffer(
+            batch_size=self.batch_size,
+            buffer_batches=self.buffer_batches,
+            shuffle=self.shuffle,
+        )
+        needs_generator = (
+            self.pipeline.requires_generator or shuffle_buffer.requires_generator
+        )
+        base_seed = (
+            self.data_pipeline_config.seed
+            if self.data_pipeline_config.seed is not None
+            else 0
+        )
+        current_file_path: str | None = None
+        current_parquet_file: pq.ParquetFile | None = None
+        current_path_crc = 0
+        last_generator: torch.Generator | None = None
         for file_path, rg_idx, _ in rg_list:
-            pf = pq.ParquetFile(file_path)
-            for batch in pf.iter_batches(batch_size=self.batch_size, row_groups=[rg_idx]):
-                batch_dict = self._convert_batch(batch)
-                if self.shuffle and self.buffer_batches > 1:
-                    buffer.append(batch_dict)
-                    if len(buffer) >= self.buffer_batches:
-                        yield from self._flush_buffer(buffer)
-                        buffer = []
-                else:
-                    yield batch_dict
+            if file_path != current_file_path:
+                current_file_path = file_path
+                current_parquet_file = pq.ParquetFile(file_path)
+                current_path_crc = zlib.crc32(file_path.encode("utf-8"))
+            if current_parquet_file is None:
+                continue
+            for batch_index, batch in enumerate(
+                current_parquet_file.iter_batches(
+                    batch_size=self.batch_size, row_groups=[rg_idx]
+                )
+            ):
+                cache_key = (file_path, rg_idx, batch_index)
+                generator: torch.Generator | None = None
+                if needs_generator:
+                    batch_seed = stable_pcvr_batch_seed_from_path_crc(
+                        base_seed=base_seed,
+                        worker_id=worker_id,
+                        path_crc=current_path_crc,
+                        row_group_index=rg_idx,
+                        batch_index=batch_index,
+                    )
+                    generator = torch.Generator().manual_seed(batch_seed)
+                    last_generator = generator
+                batch_dict = self.pipeline.read_base_batch(
+                    cache_key, lambda batch=batch: self._convert_batch(batch)
+                )
+                batch_dict = self.pipeline.apply_transforms(
+                    batch_dict, generator=generator
+                )
+                yield from shuffle_buffer.push(batch_dict, generator=generator)
 
-        if buffer:
-            yield from self._flush_buffer(buffer)
+        yield from shuffle_buffer.flush(generator=last_generator)
 
-        del buffer
+        del shuffle_buffer
         gc.collect()
 
-    def _flush_buffer(
-        self, buffer: list[dict[str, Any]]
-    ) -> Iterator[dict[str, Any]]:
+    def _flush_buffer(self, buffer: list[dict[str, Any]]) -> Iterator[dict[str, Any]]:
         """Concatenate the buffered batches, shuffle at the row level, then
         re-slice and yield batch-sized chunks.
         """
-        merged: dict[str, torch.Tensor] = {}
-        non_tensor_keys: dict[str, Any] = {}
-        for k in buffer[0].keys():
-            if isinstance(buffer[0][k], torch.Tensor):
-                merged[k] = torch.cat([b[k] for b in buffer], dim=0)
-            else:
-                non_tensor_keys[k] = buffer[0][k]
-        total_rows = merged['label'].shape[0]
-        rand_idx = torch.randperm(total_rows) if self.shuffle else torch.arange(total_rows)
-        for i in range(0, total_rows, self.batch_size):
-            end = min(i + self.batch_size, total_rows)
-            batch: dict[str, Any] = {k: v[rand_idx[i:end]] for k, v in merged.items()}
-            batch.update(non_tensor_keys)
-            yield batch
-        del merged
-        buffer.clear()
+        shuffle_buffer = PCVRShuffleBuffer(
+            batch_size=self.batch_size,
+            buffer_batches=max(1, len(buffer)),
+            shuffle=self.shuffle,
+        )
+        for batch in buffer:
+            yield from shuffle_buffer.push(batch)
+        yield from shuffle_buffer.flush()
 
     # ---- Helpers ----
 
@@ -396,12 +618,15 @@ class PCVRParquetDataset(IterableDataset):
         mn = int(oob_vals.min())
         if key in self._oob_stats:
             s = self._oob_stats[key]
-            s['count'] += n
-            s['max'] = max(s['max'], mx)
-            s['min_oob'] = min(s['min_oob'], mn)
+            s["count"] += n
+            s["max"] = max(s["max"], mx)
+            s["min_oob"] = min(s["min_oob"], mn)
         else:
             self._oob_stats[key] = {
-                'count': n, 'max': mx, 'min_oob': mn, 'vocab': vocab_size,
+                "count": n,
+                "max": mx,
+                "min_oob": mn,
+                "vocab": vocab_size,
             }
         if self.clip_vocab:
             arr[oob_mask] = 0
@@ -409,7 +634,8 @@ class PCVRParquetDataset(IterableDataset):
             raise ValueError(
                 f"{group} col_idx={col_idx}: {n} values out of range "
                 f"[0, {vocab_size}), actual=[{mn}, {mx}]. "
-                f"Use clip_vocab=True to clip or fix schema.json")
+                f"Use clip_vocab=True to clip or fix schema.json"
+            )
 
     def dump_oob_stats(self, path: str | None = None) -> None:
         """Dump out-of-bound statistics to a file if ``path`` is provided,
@@ -420,14 +646,15 @@ class PCVRParquetDataset(IterableDataset):
             return
         lines = ["=== Out-of-Bound Stats ==="]
         for (group, ci), s in sorted(self._oob_stats.items()):
-            direction = "TOO_HIGH" if s['min_oob'] >= s['vocab'] else "TOO_LOW"
+            direction = "TOO_HIGH" if s["min_oob"] >= s["vocab"] else "TOO_LOW"
             lines.append(
                 f"  {group} col_idx={ci}: vocab={s['vocab']}, "
                 f"oob_count={s['count']}, range=[{s['min_oob']}, {s['max']}], "
-                f"{direction}")
+                f"{direction}"
+            )
         msg = "\n".join(lines)
         if path:
-            with Path(path).open('w') as f:
+            with Path(path).open("w") as f:
                 f.write(msg + "\n")
             logging.info(f"OOB stats written to {path}")
         else:
@@ -460,7 +687,7 @@ class PCVRParquetDataset(IterableDataset):
             if raw_len <= 0:
                 continue
             use_len = min(raw_len, max_len)
-            padded[i, :use_len] = values[start:start + use_len]
+            padded[i, :use_len] = values[start : start + use_len]
             lengths[i] = use_len
 
         padded[padded <= 0] = 0
@@ -489,7 +716,7 @@ class PCVRParquetDataset(IterableDataset):
             if raw_len <= 0:
                 continue
             use_len = min(raw_len, max_dim)
-            padded[i, :use_len] = values[start:start + use_len]
+            padded[i, :use_len] = values[start : start + use_len]
 
         return padded
 
@@ -498,13 +725,20 @@ class PCVRParquetDataset(IterableDataset):
         B = batch.num_rows
 
         # ---- meta ----
-        timestamps = batch.column(self._col_idx['timestamp']).to_numpy().astype(np.int64)
+        timestamps = (
+            batch.column(self._col_idx["timestamp"]).to_numpy().astype(np.int64)
+        )
         if self.is_training:
-            labels = (batch.column(self._col_idx['label_type']).fill_null(0)
-                      .to_numpy(zero_copy_only=False).astype(np.int64) == 2).astype(np.int64)
+            labels = (
+                batch.column(self._col_idx["label_type"])
+                .fill_null(0)
+                .to_numpy(zero_copy_only=False)
+                .astype(np.int64)
+                == 2
+            ).astype(np.int64)
         else:
             labels = np.zeros(B, dtype=np.int64)
-        user_ids = batch.column(self._col_idx['user_id']).to_pylist()
+        user_ids = batch.column(self._col_idx["user_id"]).to_pylist()
 
         # ---- user_int: write into pre-allocated buffer ----
         # Note: null -> 0 (via fill_null), -1 -> 0 (via arr<=0); missing values
@@ -520,17 +754,17 @@ class PCVRParquetDataset(IterableDataset):
                 arr = col.fill_null(0).to_numpy(zero_copy_only=False).astype(np.int64)
                 arr[arr <= 0] = 0
                 if vs > 0:
-                    self._record_oob('user_int', ci, arr, vs)
+                    self._record_oob("user_int", ci, arr, vs)
                 else:
                     arr[:] = 0
                 user_int[:, offset] = arr
             else:
                 padded, _ = self._pad_varlen_int_column(col, dim, B)
                 if vs > 0:
-                    self._record_oob('user_int', ci, padded, vs)
+                    self._record_oob("user_int", ci, padded, vs)
                 else:
                     padded[:] = 0
-                user_int[:, offset:offset + dim] = padded
+                user_int[:, offset : offset + dim] = padded
 
         # ---- item_int ----
         item_int = self._buf_item_int[:B]
@@ -541,17 +775,17 @@ class PCVRParquetDataset(IterableDataset):
                 arr = col.fill_null(0).to_numpy(zero_copy_only=False).astype(np.int64)
                 arr[arr <= 0] = 0
                 if vs > 0:
-                    self._record_oob('item_int', ci, arr, vs)
+                    self._record_oob("item_int", ci, arr, vs)
                 else:
                     arr[:] = 0
                 item_int[:, offset] = arr
             else:
                 padded, _ = self._pad_varlen_int_column(col, dim, B)
                 if vs > 0:
-                    self._record_oob('item_int', ci, padded, vs)
+                    self._record_oob("item_int", ci, padded, vs)
                 else:
                     padded[:] = 0
-                item_int[:, offset:offset + dim] = padded
+                item_int[:, offset : offset + dim] = padded
 
         # ---- user_dense ----
         user_dense = self._buf_user_dense[:B]
@@ -559,17 +793,17 @@ class PCVRParquetDataset(IterableDataset):
         for ci, dim, offset in self._user_dense_plan:
             col = batch.column(ci)
             padded = self._pad_varlen_float_column(col, dim, B)
-            user_dense[:, offset:offset + dim] = padded
+            user_dense[:, offset : offset + dim] = padded
 
         result = {
-            'user_int_feats': torch.from_numpy(user_int.copy()),
-            'user_dense_feats': torch.from_numpy(user_dense.copy()),
-            'item_int_feats': torch.from_numpy(item_int.copy()),
-            'item_dense_feats': torch.zeros(B, 0, dtype=torch.float32),
-            'label': torch.from_numpy(labels),
-            'timestamp': torch.from_numpy(timestamps),
-            'user_id': user_ids,
-            '_seq_domains': self.seq_domains,
+            "user_int_feats": torch.from_numpy(user_int.copy()),
+            "user_dense_feats": torch.from_numpy(user_dense.copy()),
+            "item_int_feats": torch.from_numpy(item_int.copy()),
+            "item_dense_feats": torch.zeros(B, 0, dtype=torch.float32),
+            "label": torch.from_numpy(labels),
+            "timestamp": torch.from_numpy(timestamps),
+            "user_id": user_ids,
+            "_seq_domains": self.seq_domains,
         }
 
         # ---- Sequence features: fused padding directly into the 3D buffer ----
@@ -590,17 +824,79 @@ class PCVRParquetDataset(IterableDataset):
                 col = batch.column(ci)
                 col_data.append((col.offsets.to_numpy(), col.values.to_numpy(), vs, ci))
 
-            for c, (offs, vals, _vs, _ci) in enumerate(col_data):
-                for i in range(B):
-                    s = int(offs[i])
-                    e = int(offs[i + 1])
-                    rl = e - s
-                    if rl <= 0:
+            ts_padded = np.zeros((B, max_len), dtype=np.int64)
+            if self._strict_time_filter and ts_ci is not None:
+                ts_col = batch.column(ts_ci)
+                ts_offsets = ts_col.offsets.to_numpy()
+                ts_values = ts_col.values.to_numpy()
+                for row_index in range(B):
+                    timestamp_start = int(ts_offsets[row_index])
+                    timestamp_end = int(ts_offsets[row_index + 1])
+                    if timestamp_end <= timestamp_start:
                         continue
-                    ul = min(rl, max_len)
-                    out[i, c, :ul] = vals[s:s + ul]
-                    if ul > lengths[i]:
-                        lengths[i] = ul
+                    row_timestamps = ts_values[timestamp_start:timestamp_end]
+                    valid_positions = np.flatnonzero(
+                        (row_timestamps > 0) & (row_timestamps < timestamps[row_index])
+                    )
+                    if valid_positions.size == 0:
+                        continue
+                    if valid_positions.size > max_len:
+                        valid_positions = valid_positions[-max_len:]
+
+                    view_len = int(valid_positions.size)
+                    lengths[row_index] = view_len
+                    ts_padded[row_index, :view_len] = row_timestamps[valid_positions]
+                    for feature_index, (
+                        side_offsets,
+                        side_values,
+                        _vocab_size,
+                        _col_idx,
+                    ) in enumerate(col_data):
+                        side_start = int(side_offsets[row_index])
+                        side_end = int(side_offsets[row_index + 1])
+                        side_len = side_end - side_start
+                        if side_len <= 0:
+                            continue
+                        side_positions = valid_positions[valid_positions < side_len]
+                        if side_positions.size == 0:
+                            continue
+                        out[row_index, feature_index, : side_positions.size] = (
+                            side_values[side_start + side_positions]
+                        )
+            else:
+                for feature_index, (
+                    side_offsets,
+                    side_values,
+                    _vocab_size,
+                    _col_idx,
+                ) in enumerate(col_data):
+                    for row_index in range(B):
+                        start = int(side_offsets[row_index])
+                        end = int(side_offsets[row_index + 1])
+                        raw_len = end - start
+                        if raw_len <= 0:
+                            continue
+                        use_len = min(raw_len, max_len)
+                        out[row_index, feature_index, :use_len] = side_values[
+                            start : start + use_len
+                        ]
+                        if use_len > lengths[row_index]:
+                            lengths[row_index] = use_len
+
+                if ts_ci is not None:
+                    ts_col = batch.column(ts_ci)
+                    ts_offsets = ts_col.offsets.to_numpy()
+                    ts_values = ts_col.values.to_numpy()
+                    for row_index in range(B):
+                        start = int(ts_offsets[row_index])
+                        end = int(ts_offsets[row_index + 1])
+                        raw_len = end - start
+                        if raw_len <= 0:
+                            continue
+                        use_len = min(raw_len, max_len)
+                        ts_padded[row_index, :use_len] = ts_values[
+                            start : start + use_len
+                        ]
 
             # Values <= 0 -> 0.
             out[out <= 0] = 0
@@ -611,31 +907,17 @@ class PCVRParquetDataset(IterableDataset):
             for c, (_, _, vs, ci) in enumerate(col_data):
                 slice_c = out[:, c, :]
                 if vs > 0:
-                    self._record_oob(f'seq_{domain}', ci, slice_c, vs)
+                    self._record_oob(f"seq_{domain}", ci, slice_c, vs)
                 else:
                     slice_c[:] = 0
 
             result[domain] = torch.from_numpy(out.copy())
-            result[f'{domain}_len'] = torch.from_numpy(lengths.copy())
+            result[f"{domain}_len"] = torch.from_numpy(lengths.copy())
 
             # Time bucketing.
             time_bucket = self._buf_seq_tb[domain][:B]
             time_bucket[:] = 0
             if ts_ci is not None:
-                ts_col = batch.column(ts_ci)
-                ts_offs = ts_col.offsets.to_numpy()
-                ts_vals = ts_col.values.to_numpy()
-                # Pad timestamps into shape (B, max_len).
-                ts_padded = np.zeros((B, max_len), dtype=np.int64)
-                for i in range(B):
-                    s = int(ts_offs[i])
-                    e = int(ts_offs[i + 1])
-                    rl = e - s
-                    if rl <= 0:
-                        continue
-                    ul = min(rl, max_len)
-                    ts_padded[i, :ul] = ts_vals[s:s + ul]
-
                 ts_expanded = timestamps.reshape(-1, 1)
                 time_diff = np.maximum(ts_expanded - ts_padded, 0)
                 # np.searchsorted returns values in [0, len(BUCKET_BOUNDARIES)].
@@ -649,13 +931,14 @@ class PCVRParquetDataset(IterableDataset):
                 # largest boundary collapse into the last bucket.
                 raw_buckets = np.clip(
                     np.searchsorted(BUCKET_BOUNDARIES, time_diff.ravel()),
-                    0, len(BUCKET_BOUNDARIES) - 1,
+                    0,
+                    len(BUCKET_BOUNDARIES) - 1,
                 )
                 buckets = raw_buckets.reshape(B, max_len) + 1
                 buckets[ts_padded == 0] = 0
                 time_bucket[:] = buckets
 
-            result[f'{domain}_time_bucket'] = torch.from_numpy(time_bucket.copy())
+            result[f"{domain}_time_bucket"] = torch.from_numpy(time_bucket.copy())
 
         return result
 
@@ -672,6 +955,7 @@ def get_pcvr_data(
     seed: int = 42,
     clip_vocab: bool = True,
     seq_max_lens: dict[str, int] | None = None,
+    data_pipeline_config: PCVRDataPipelineConfig | None = None,
     **kwargs: Any,
 ) -> tuple[DataLoader, DataLoader, PCVRParquetDataset]:
     """Create train / valid DataLoaders from raw multi-column Parquet files.
@@ -687,54 +971,30 @@ def get_pcvr_data(
     """
     random.seed(seed)
 
-    data_path = Path(data_dir).expanduser()
-    if data_path.is_dir():
-        pq_files = sorted(str(path) for path in data_path.glob('*.parquet'))
-    else:
-        pq_files = [str(data_path)]
-    if not pq_files:
-        raise FileNotFoundError(f"No .parquet files found at {data_dir}")
-
-    rg_info = []
-    for f in pq_files:
-        pf = pq.ParquetFile(f)
-        for i in range(pf.metadata.num_row_groups):
-            rg_info.append((f, i, pf.metadata.row_group(i).num_rows))
-    total_rgs = len(rg_info)
-
-    n_valid_rgs = max(1, int(total_rgs * valid_ratio))
-    n_train_rgs = total_rgs - n_valid_rgs
-    reuse_train_for_valid = False
-
-    if total_rgs == 1:
-        # Official sample_1000 ships as a single Row Group parquet file. Reuse it
-        # for validation so smoke runs still exercise the full training pipeline.
-        n_train_rgs = 1
-        n_valid_rgs = 1
-        reuse_train_for_valid = True
-    elif n_train_rgs == 0:
-        n_train_rgs = total_rgs - 1
-        n_valid_rgs = 1
+    rg_info = collect_pcvr_row_groups(data_dir)
+    split_plan = plan_pcvr_row_group_split(
+        rg_info, valid_ratio=valid_ratio, train_ratio=train_ratio
+    )
 
     # train_ratio: use only the first N% of the training Row Groups.
-    if train_ratio < 1.0 and not reuse_train_for_valid:
-        n_train_rgs = max(1, int(n_train_rgs * train_ratio))
-        logging.info(f"train_ratio={train_ratio}: using {n_train_rgs} train Row Groups")
+    if train_ratio < 1.0 and not split_plan.reuse_train_for_valid:
+        logging.info(
+            f"train_ratio={train_ratio}: using {split_plan.train_row_groups} train Row Groups"
+        )
 
-    train_row_group_range = (0, n_train_rgs)
-    valid_row_group_range = (0, total_rgs) if reuse_train_for_valid else (n_train_rgs, total_rgs)
-
-    train_rows = sum(r[2] for r in rg_info[train_row_group_range[0] : train_row_group_range[1]])
-    valid_rows = sum(r[2] for r in rg_info[valid_row_group_range[0] : valid_row_group_range[1]])
-
-    if reuse_train_for_valid:
+    if split_plan.reuse_train_for_valid:
         logging.warning(
             "Single Row Group parquet detected; reusing the same Row Group for train and valid "
             "to keep smoke runs functional"
         )
 
-    logging.info(f"Row Group split: {n_train_rgs} train ({train_rows} rows), "
-                 f"{n_valid_rgs} valid ({valid_rows} rows)")
+    logging.info(
+        f"Row Group split: {split_plan.train_row_groups} train ({split_plan.train_rows} rows), "
+        f"{split_plan.valid_row_groups} valid ({split_plan.valid_rows} rows)"
+    )
+
+    train_pipeline_config = data_pipeline_config or PCVRDataPipelineConfig()
+    valid_pipeline_config = PCVRDataPipelineConfig(cache=train_pipeline_config.cache)
 
     train_dataset = PCVRParquetDataset(
         parquet_path=data_dir,
@@ -743,19 +1003,24 @@ def get_pcvr_data(
         seq_max_lens=seq_max_lens,
         shuffle=shuffle_train,
         buffer_batches=buffer_batches,
-        row_group_range=train_row_group_range,
+        row_group_range=split_plan.train_row_group_range,
         clip_vocab=clip_vocab,
+        data_pipeline_config=train_pipeline_config,
+        is_training=True,
     )
 
     use_cuda = torch.cuda.is_available()
     _train_kw = {}
     if num_workers > 0:
-        _train_kw['persistent_workers'] = True
-        _train_kw['prefetch_factor'] = 2
+        _train_kw["persistent_workers"] = True
+        _train_kw["prefetch_factor"] = 2
 
     train_loader = DataLoader(
-        train_dataset, batch_size=None,
-        num_workers=num_workers, pin_memory=use_cuda, **_train_kw,
+        train_dataset,
+        batch_size=None,
+        num_workers=num_workers,
+        pin_memory=use_cuda,
+        **_train_kw,
     )
 
     valid_dataset = PCVRParquetDataset(
@@ -765,15 +1030,21 @@ def get_pcvr_data(
         seq_max_lens=seq_max_lens,
         shuffle=False,
         buffer_batches=0,
-        row_group_range=valid_row_group_range,
+        row_group_range=split_plan.valid_row_group_range,
         clip_vocab=clip_vocab,
+        data_pipeline_config=valid_pipeline_config,
+        is_training=True,
     )
     valid_loader = DataLoader(
-        valid_dataset, batch_size=None,
-        num_workers=0, pin_memory=use_cuda,
+        valid_dataset,
+        batch_size=None,
+        num_workers=0,
+        pin_memory=use_cuda,
     )
 
-    logging.info(f"Parquet train: {train_rows} rows, valid: {valid_rows} rows, "
-                 f"batch_size={batch_size}, buffer_batches={buffer_batches}")
+    logging.info(
+        f"Parquet train: {split_plan.train_rows} rows, valid: {split_plan.valid_rows} rows, "
+        f"batch_size={batch_size}, buffer_batches={buffer_batches}"
+    )
 
     return train_loader, valid_loader, train_dataset

--- a/src/taac2026/infrastructure/pcvr/data_pipeline.py
+++ b/src/taac2026/infrastructure/pcvr/data_pipeline.py
@@ -1,0 +1,515 @@
+"""Composable PCVR data pipeline components."""
+
+from __future__ import annotations
+
+import zlib
+from collections import OrderedDict
+from collections.abc import Callable, Hashable, Iterator
+from typing import Any, Protocol
+
+import torch
+
+from taac2026.infrastructure.pcvr.config import (
+    PCVRDataCacheConfig,
+    PCVRDataPipelineConfig,
+    PCVRDataTransformConfig,
+    PCVRDomainDropoutConfig,
+    PCVRFeatureMaskConfig,
+    PCVRSequenceCropConfig,
+)
+
+
+PCVRBatch = dict[str, Any]
+PCVRBatchFactory = Callable[[], PCVRBatch]
+
+
+class PCVRBatchTransform(Protocol):
+    def __call__(self, batch: PCVRBatch, *, generator: torch.Generator) -> PCVRBatch:
+        """Return a transformed PCVR batch."""
+
+
+def pcvr_batch_row_count(batch: PCVRBatch) -> int:
+    label = batch.get("label")
+    if isinstance(label, torch.Tensor) and label.ndim > 0:
+        return int(label.shape[0])
+    for value in batch.values():
+        if isinstance(value, torch.Tensor) and value.ndim > 0:
+            return int(value.shape[0])
+    return 0
+
+
+def clone_pcvr_batch(batch: PCVRBatch) -> PCVRBatch:
+    cloned: PCVRBatch = {}
+    for key, value in batch.items():
+        if isinstance(value, torch.Tensor):
+            cloned[key] = value.clone()
+        elif isinstance(value, list):
+            cloned[key] = list(value)
+        elif isinstance(value, tuple):
+            cloned[key] = tuple(value)
+        else:
+            cloned[key] = value
+    return cloned
+
+
+def repeat_pcvr_rows(batch: PCVRBatch, repeats: int) -> PCVRBatch:
+    if repeats <= 1:
+        return clone_pcvr_batch(batch)
+
+    row_count = pcvr_batch_row_count(batch)
+    repeated: PCVRBatch = {}
+    for key, value in batch.items():
+        if key == "_seq_domains":
+            repeated[key] = list(value)
+        elif (
+            isinstance(value, torch.Tensor)
+            and value.ndim > 0
+            and value.shape[0] == row_count
+        ):
+            repeated[key] = value.repeat_interleave(repeats, dim=0)
+        elif isinstance(value, list) and len(value) == row_count:
+            repeated[key] = [item for item in value for _repeat_index in range(repeats)]
+        else:
+            repeated[key] = clone_pcvr_batch({key: value})[key]
+    return repeated
+
+
+def take_pcvr_rows(batch: PCVRBatch, row_indices: torch.Tensor) -> PCVRBatch:
+    row_count = pcvr_batch_row_count(batch)
+    indices = row_indices.detach().cpu().tolist()
+    sliced: PCVRBatch = {}
+    for key, value in batch.items():
+        if key == "_seq_domains":
+            sliced[key] = list(value)
+        elif (
+            isinstance(value, torch.Tensor)
+            and value.ndim > 0
+            and value.shape[0] == row_count
+        ):
+            sliced[key] = value.index_select(0, row_indices.to(value.device))
+        elif isinstance(value, list) and len(value) == row_count:
+            sliced[key] = [value[index] for index in indices]
+        else:
+            sliced[key] = clone_pcvr_batch({key: value})[key]
+    return sliced
+
+
+def concat_pcvr_batches(batches: list[PCVRBatch]) -> PCVRBatch:
+    if not batches:
+        return {}
+
+    row_counts = [pcvr_batch_row_count(batch) for batch in batches]
+    merged: PCVRBatch = {}
+    for key, first_value in batches[0].items():
+        if key == "_seq_domains":
+            merged[key] = list(first_value)
+        elif isinstance(first_value, torch.Tensor):
+            merged[key] = torch.cat([batch[key] for batch in batches], dim=0)
+        elif isinstance(first_value, list) and all(
+            len(batch[key]) == row_count
+            for batch, row_count in zip(batches, row_counts, strict=True)
+        ):
+            merged[key] = [item for batch in batches for item in batch[key]]
+        else:
+            merged[key] = clone_pcvr_batch({key: first_value})[key]
+    return merged
+
+
+class PCVRMemoryBatchCache:
+    """Small per-process LRU cache for converted base PCVR batches."""
+
+    def __init__(self, *, enabled: bool = False, max_batches: int = 0) -> None:
+        self.enabled = enabled
+        self.max_batches = max(0, int(max_batches))
+        self._items: OrderedDict[Hashable, PCVRBatch] = OrderedDict()
+
+    @classmethod
+    def from_config(cls, config: PCVRDataCacheConfig | None) -> PCVRMemoryBatchCache:
+        if config is None:
+            return cls()
+        return cls(enabled=config.enabled, max_batches=config.max_batches)
+
+    def get(self, key: Hashable) -> PCVRBatch | None:
+        if not self.enabled:
+            return None
+        batch = self._items.get(key)
+        if batch is None:
+            return None
+        self._items.move_to_end(key)
+        return clone_pcvr_batch(batch)
+
+    def put(self, key: Hashable, batch: PCVRBatch) -> None:
+        if not self.enabled:
+            return
+        self._items[key] = clone_pcvr_batch(batch)
+        self._items.move_to_end(key)
+        while self.max_batches > 0 and len(self._items) > self.max_batches:
+            self._items.popitem(last=False)
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+
+class PCVRDataPipeline:
+    """Compose cache and row-level transforms around Parquet batch conversion."""
+
+    def __init__(
+        self,
+        *,
+        cache: PCVRMemoryBatchCache | None = None,
+        transforms: list[PCVRBatchTransform] | tuple[PCVRBatchTransform, ...] = (),
+    ) -> None:
+        self.cache = cache or PCVRMemoryBatchCache()
+        self.transforms = tuple(transforms)
+
+    @property
+    def requires_generator(self) -> bool:
+        return bool(self.transforms)
+
+    def read_base_batch(self, key: Hashable, factory: PCVRBatchFactory) -> PCVRBatch:
+        cached = self.cache.get(key)
+        if cached is not None:
+            return cached
+        batch = factory()
+        self.cache.put(key, batch)
+        return batch
+
+    def apply_transforms(
+        self, batch: PCVRBatch, *, generator: torch.Generator | None = None
+    ) -> PCVRBatch:
+        if not self.transforms:
+            return batch
+        if generator is None:
+            generator = torch.Generator()
+        transformed = batch
+        for transform in self.transforms:
+            transformed = transform(transformed, generator=generator)
+        return transformed
+
+
+class PCVRShuffleBuffer:
+    """Row-level shuffle buffer for pre-batched PCVR tensor dictionaries."""
+
+    def __init__(self, *, batch_size: int, buffer_batches: int, shuffle: bool) -> None:
+        self.batch_size = int(batch_size)
+        self.buffer_batches = int(buffer_batches)
+        self.shuffle = shuffle
+        self._buffer: list[PCVRBatch] = []
+
+    @property
+    def requires_generator(self) -> bool:
+        return self.shuffle and self.buffer_batches > 1
+
+    def push(
+        self, batch: PCVRBatch, *, generator: torch.Generator | None = None
+    ) -> Iterator[PCVRBatch]:
+        if self.shuffle and self.buffer_batches > 1:
+            self._buffer.append(batch)
+            if len(self._buffer) >= self.buffer_batches:
+                yield from self.flush(generator=generator)
+        else:
+            yield batch
+
+    def flush(self, *, generator: torch.Generator | None = None) -> Iterator[PCVRBatch]:
+        if not self._buffer:
+            return
+        merged = concat_pcvr_batches(self._buffer)
+        total_rows = pcvr_batch_row_count(merged)
+        if self.shuffle:
+            row_order = torch.randperm(total_rows, generator=generator)
+        else:
+            row_order = torch.arange(total_rows)
+        for start in range(0, total_rows, self.batch_size):
+            end = min(start + self.batch_size, total_rows)
+            yield take_pcvr_rows(merged, row_order[start:end])
+        self._buffer.clear()
+
+
+class PCVRSequenceCropTransform:
+    """Create time-safe sequence views from each batch."""
+
+    def __init__(self, config: PCVRSequenceCropConfig) -> None:
+        self.config = config
+
+    def __call__(self, batch: PCVRBatch, *, generator: torch.Generator) -> PCVRBatch:
+        if not self.config.enabled:
+            return clone_pcvr_batch(batch)
+
+        augmented = repeat_pcvr_rows(batch, max(1, int(self.config.views_per_row)))
+        self._apply_sequence_crop(augmented, generator=generator)
+        return augmented
+
+    def _apply_sequence_crop(
+        self, batch: PCVRBatch, *, generator: torch.Generator
+    ) -> None:
+        for domain in batch.get("_seq_domains", []):
+            sequence = batch.get(domain)
+            lengths = batch.get(f"{domain}_len")
+            time_buckets = batch.get(f"{domain}_time_bucket")
+            if not isinstance(sequence, torch.Tensor) or not isinstance(
+                lengths, torch.Tensor
+            ):
+                continue
+            if not isinstance(time_buckets, torch.Tensor):
+                time_buckets = torch.zeros(
+                    sequence.shape[0], sequence.shape[2], dtype=torch.long
+                )
+                batch[f"{domain}_time_bucket"] = time_buckets
+            self._crop_domain(sequence, lengths, time_buckets, generator=generator)
+
+    def _crop_domain(
+        self,
+        sequence: torch.Tensor,
+        lengths: torch.Tensor,
+        time_buckets: torch.Tensor,
+        *,
+        generator: torch.Generator,
+    ) -> None:
+        max_len = int(sequence.shape[2])
+        if max_len <= 0 or sequence.shape[0] == 0:
+            return
+
+        row_count = int(sequence.shape[0])
+        device = sequence.device
+        length_values = lengths.clamp(min=0, max=max_len)
+        active_rows = length_values > 0
+        if not bool(active_rows.any()):
+            return
+
+        min_len_config = max(1, int(self.config.seq_window_min_len))
+        min_lengths = torch.minimum(
+            torch.full_like(length_values, min_len_config), length_values
+        ).clamp(min=1)
+
+        if self.config.seq_window_mode == "tail":
+            window_lengths = length_values
+        else:
+            span = (length_values - min_lengths + 1).clamp(min=1)
+            draws = torch.floor(
+                torch.rand(row_count, generator=generator, device=device)
+                * span.to(torch.float32)
+            ).to(length_values.dtype)
+            window_lengths = torch.where(
+                active_rows, min_lengths + draws, torch.zeros_like(length_values)
+            )
+
+        if self.config.seq_window_mode == "rolling":
+            max_starts = (length_values - window_lengths).clamp(min=0)
+            start_draws = torch.floor(
+                torch.rand(row_count, generator=generator, device=device)
+                * (max_starts + 1).to(torch.float32)
+            ).to(length_values.dtype)
+            starts = torch.where(
+                active_rows, start_draws, torch.zeros_like(length_values)
+            )
+        else:
+            starts = (length_values - window_lengths).clamp(min=0)
+
+        positions = starts.view(-1, 1) + torch.arange(max_len, device=device).view(
+            1, -1
+        )
+        positions = positions.clamp(max=max_len - 1).to(torch.long)
+        valid_positions = torch.arange(max_len, device=device).view(
+            1, -1
+        ) < window_lengths.view(-1, 1)
+
+        sequence_positions = positions.view(row_count, 1, max_len).expand(
+            row_count, sequence.shape[1], max_len
+        )
+        cropped_sequence = sequence.gather(2, sequence_positions)
+        sequence.copy_(
+            cropped_sequence.masked_fill(
+                ~valid_positions.view(row_count, 1, max_len), 0
+            )
+        )
+
+        cropped_time = time_buckets.gather(1, positions)
+        time_buckets.copy_(cropped_time.masked_fill(~valid_positions, 0))
+        lengths.copy_(window_lengths.to(lengths.dtype))
+
+
+class PCVRDomainDropoutTransform:
+    """Drop whole sequence domains for selected rows."""
+
+    def __init__(self, config: PCVRDomainDropoutConfig) -> None:
+        self.config = config
+
+    def __call__(self, batch: PCVRBatch, *, generator: torch.Generator) -> PCVRBatch:
+        if not self.config.enabled:
+            return clone_pcvr_batch(batch)
+        augmented = clone_pcvr_batch(batch)
+        self._apply_domain_dropout(augmented, generator=generator)
+        return augmented
+
+    def _apply_domain_dropout(
+        self, batch: PCVRBatch, *, generator: torch.Generator
+    ) -> None:
+        probability = float(self.config.probability)
+        if probability <= 0.0:
+            return
+        for domain in batch.get("_seq_domains", []):
+            sequence = batch.get(domain)
+            lengths = batch.get(f"{domain}_len")
+            time_buckets = batch.get(f"{domain}_time_bucket")
+            if not isinstance(sequence, torch.Tensor) or not isinstance(
+                lengths, torch.Tensor
+            ):
+                continue
+            drop_mask = torch.rand(sequence.shape[0], generator=generator) < probability
+            if not bool(drop_mask.any()):
+                continue
+            sequence[drop_mask] = 0
+            lengths[drop_mask] = 0
+            if isinstance(time_buckets, torch.Tensor):
+                time_buckets[drop_mask] = 0
+
+
+class PCVRFeatureMaskTransform:
+    """Mask sparse features and sequence events in a batch."""
+
+    def __init__(self, config: PCVRFeatureMaskConfig) -> None:
+        self.config = config
+
+    def __call__(self, batch: PCVRBatch, *, generator: torch.Generator) -> PCVRBatch:
+        if not self.config.enabled:
+            return clone_pcvr_batch(batch)
+        augmented = clone_pcvr_batch(batch)
+        self._apply_feature_masking(augmented, generator=generator)
+        return augmented
+
+    def _apply_feature_masking(
+        self, batch: PCVRBatch, *, generator: torch.Generator
+    ) -> None:
+        probability = float(self.config.probability)
+        if probability <= 0.0:
+            return
+
+        for feature_key in ("user_int_feats", "item_int_feats"):
+            features = batch.get(feature_key)
+            if isinstance(features, torch.Tensor) and features.numel() > 0:
+                mask = torch.rand(features.shape, generator=generator) < probability
+                features[mask] = 0
+
+        for domain in batch.get("_seq_domains", []):
+            sequence = batch.get(domain)
+            lengths = batch.get(f"{domain}_len")
+            time_buckets = batch.get(f"{domain}_time_bucket")
+            if not isinstance(sequence, torch.Tensor) or not isinstance(
+                lengths, torch.Tensor
+            ):
+                continue
+            valid_positions = torch.arange(sequence.shape[2]).view(
+                1, -1
+            ) < lengths.view(-1, 1)
+            event_mask = (
+                torch.rand(valid_positions.shape, generator=generator) < probability
+            ) & valid_positions
+            if bool(event_mask.any()):
+                expanded_mask = event_mask.unsqueeze(1).expand_as(sequence)
+                sequence[expanded_mask] = 0
+                if isinstance(time_buckets, torch.Tensor):
+                    time_buckets[event_mask] = 0
+                self._compact_domain(
+                    sequence,
+                    lengths,
+                    time_buckets if isinstance(time_buckets, torch.Tensor) else None,
+                    row_mask=event_mask.any(dim=1),
+                )
+
+    def _compact_domain(
+        self,
+        sequence: torch.Tensor,
+        lengths: torch.Tensor,
+        time_buckets: torch.Tensor | None,
+        *,
+        row_mask: torch.Tensor | None = None,
+    ) -> None:
+        max_len = int(sequence.shape[2])
+        valid_positions = (sequence > 0).any(dim=1)
+        if row_mask is None:
+            row_indices = range(sequence.shape[0])
+        else:
+            row_indices = torch.nonzero(row_mask, as_tuple=False).flatten().tolist()
+        for row_index in row_indices:
+            row_positions = torch.nonzero(
+                valid_positions[row_index], as_tuple=False
+            ).flatten()
+            new_len = min(int(row_positions.numel()), max_len)
+            if new_len <= 0:
+                sequence[row_index].zero_()
+                lengths[row_index] = 0
+                if time_buckets is not None:
+                    time_buckets[row_index].zero_()
+                continue
+            selected_sequence = sequence[row_index, :, row_positions[:new_len]].clone()
+            sequence[row_index].zero_()
+            sequence[row_index, :, :new_len] = selected_sequence
+            lengths[row_index] = new_len
+            if time_buckets is not None:
+                selected_time = time_buckets[row_index, row_positions[:new_len]].clone()
+                time_buckets[row_index].zero_()
+                time_buckets[row_index, :new_len] = selected_time
+
+
+def build_pcvr_batch_transform(config: PCVRDataTransformConfig) -> PCVRBatchTransform:
+    if isinstance(config, PCVRSequenceCropConfig):
+        return PCVRSequenceCropTransform(config)
+    if isinstance(config, PCVRFeatureMaskConfig):
+        return PCVRFeatureMaskTransform(config)
+    if isinstance(config, PCVRDomainDropoutConfig):
+        return PCVRDomainDropoutTransform(config)
+    raise TypeError(f"unsupported PCVR data transform config: {type(config).__name__}")
+
+
+def build_pcvr_batch_transforms(
+    config: PCVRDataPipelineConfig,
+) -> tuple[PCVRBatchTransform, ...]:
+    return tuple(
+        build_pcvr_batch_transform(transform)
+        for transform in config.transforms
+        if transform.enabled and not _is_noop_pcvr_batch_transform_config(transform)
+    )
+
+
+def _is_noop_pcvr_batch_transform_config(config: PCVRDataTransformConfig) -> bool:
+    if isinstance(config, PCVRSequenceCropConfig):
+        return config.views_per_row <= 1 and config.seq_window_mode == "tail"
+    if isinstance(config, (PCVRFeatureMaskConfig, PCVRDomainDropoutConfig)):
+        return float(config.probability) <= 0.0
+    return False
+
+
+def stable_pcvr_batch_seed_from_path_crc(
+    *,
+    base_seed: int,
+    worker_id: int,
+    path_crc: int,
+    row_group_index: int,
+    batch_index: int,
+) -> int:
+    seed = (
+        int(base_seed)
+        + worker_id * 1_000_003
+        + int(path_crc)
+        + row_group_index * 10_007
+        + batch_index * 101
+    )
+    return seed % (2**63 - 1)
+
+
+def stable_pcvr_batch_seed(
+    *,
+    base_seed: int,
+    worker_id: int,
+    file_path: str,
+    row_group_index: int,
+    batch_index: int,
+) -> int:
+    path_crc = zlib.crc32(file_path.encode("utf-8"))
+    return stable_pcvr_batch_seed_from_path_crc(
+        base_seed=base_seed,
+        worker_id=worker_id,
+        path_crc=path_crc,
+        row_group_index=row_group_index,
+        batch_index=batch_index,
+    )

--- a/src/taac2026/infrastructure/pcvr/experiment.py
+++ b/src/taac2026/infrastructure/pcvr/experiment.py
@@ -9,7 +9,7 @@ import sys
 import time
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -18,12 +18,12 @@ import torch
 from torch.utils.data import DataLoader
 
 from taac2026.domain.config import EvalRequest, InferRequest, TrainRequest
-from taac2026.domain.metrics import binary_auc, binary_logloss
+from taac2026.domain.metrics import compute_classification_metrics
 from taac2026.infrastructure.checkpoints import resolve_checkpoint_path
 from taac2026.infrastructure.io.files import read_json, write_json
 import taac2026.infrastructure.pcvr.data as pcvr_data
+from taac2026.infrastructure.pcvr.config import PCVRTrainConfig, REQUIRED_PCVR_TRAIN_CONFIG_KEYS
 from taac2026.infrastructure.pcvr.protocol import (
-    DEFAULT_PCVR_MODEL_CONFIG,
     batch_to_model_input,
     build_pcvr_model,
     parse_seq_max_lens,
@@ -38,6 +38,7 @@ _PLUGIN_MODULE_NAMES = ("utils", "model")
 _INFER_REQUEST_DEFAULT_BATCH_SIZE = int(InferRequest.__dataclass_fields__["batch_size"].default)
 _INFER_REQUEST_DEFAULT_NUM_WORKERS = int(InferRequest.__dataclass_fields__["num_workers"].default)
 _PREDICTION_PROGRESS_LOG_EVERY_ROWS = 50_000
+_EVAL_AUC_BOOTSTRAP_SAMPLES = 200
 
 
 def _coerce_optional_int(value: Any) -> int | None:
@@ -49,32 +50,11 @@ def _coerce_optional_int(value: Any) -> int | None:
         return None
 
 
-def _read_flag_value(args: tuple[str, ...], flag_names: tuple[str, ...]) -> str | None:
-    index = 0
-    while index < len(args):
-        token = args[index]
-        has_value = index + 1 < len(args) and not args[index + 1].startswith("--")
-        if token in flag_names:
-            return args[index + 1] if has_value else None
-        if token.startswith("--") and has_value:
-            index += 2
-        else:
-            index += 1
-    return None
-
-
-def _read_bool_flag_value(
-    args: tuple[str, ...],
-    enabled_flags: tuple[str, ...],
-    disabled_flags: tuple[str, ...],
-) -> bool | None:
-    resolved: bool | None = None
-    for token in args:
-        if token in enabled_flags:
-            resolved = True
-        elif token in disabled_flags:
-            resolved = False
-    return resolved
+def _required_config_value(config: dict[str, Any], config_key: str) -> Any:
+    try:
+        return config[config_key]
+    except KeyError as error:
+        raise KeyError(f"PCVR train_config is missing required key: {config_key}") from error
 
 
 def _log_prediction_progress(
@@ -104,7 +84,7 @@ class PCVRExperiment:
     name: str
     package_dir: Path
     model_class_name: str
-    default_train_args: tuple[str, ...] = ()
+    train_defaults: PCVRTrainConfig = field(default_factory=PCVRTrainConfig)
 
     @property
     def metadata(self) -> dict[str, str]:
@@ -146,7 +126,6 @@ class PCVRExperiment:
             str(train_log_dir),
             "--tf_events_dir",
             str(tensorboard_dir),
-            *self.default_train_args,
         ]
         if request.schema_path is not None:
             forwarded_args.extend(["--schema_path", str(request.schema_path.expanduser().resolve())])
@@ -159,6 +138,7 @@ class PCVRExperiment:
                 model_module=model_module,
                 model_class_name=self.model_class_name,
                 package_dir=self.package_dir,
+                defaults=self.train_defaults,
                 argv=forwarded_args,
             )
 
@@ -212,11 +192,11 @@ class PCVRExperiment:
 
         labels = np.asarray(evaluation["labels"], dtype=np.float64)
         probabilities = np.asarray(evaluation["probabilities"], dtype=np.float64)
-        metrics = {
-            "auc": binary_auc(labels, probabilities),
-            "logloss": binary_logloss(labels, probabilities),
-            "sample_count": int(labels.size),
-        }
+        metrics = compute_classification_metrics(
+            labels,
+            probabilities,
+            auc_bootstrap_samples=_EVAL_AUC_BOOTSTRAP_SAMPLES,
+        )
         rows = [
             json.dumps(record, ensure_ascii=False)
             for record in evaluation["records"]
@@ -227,10 +207,48 @@ class PCVRExperiment:
             "experiment_name": self.name,
             "checkpoint_path": str(checkpoint),
             "metrics": metrics,
+            "data_diagnostics": self._build_evaluation_data_diagnostics(request.dataset_path),
             "validation_predictions_path": str(predictions_path),
         }
         write_json(output_path, payload)
         return payload
+
+    def _build_evaluation_data_diagnostics(self, dataset_path: Path) -> dict[str, Any]:
+        resolved_dataset_path = dataset_path.expanduser()
+        warnings: list[str] = []
+        try:
+            rg_info = pcvr_data.collect_pcvr_row_groups(resolved_dataset_path)
+            split_plan = pcvr_data.plan_pcvr_row_group_split(rg_info)
+        except (FileNotFoundError, OSError, ValueError) as error:
+            return {
+                "dataset_path": str(resolved_dataset_path),
+                "warnings": [f"row group diagnostics unavailable: {error}"],
+            }
+
+        files = sorted({path for path, _index, _rows in rg_info})
+        if split_plan.reuse_train_for_valid:
+            warnings.append("single Row Group dataset would reuse train rows for validation; treat as L0 smoke only")
+        if not split_plan.is_l1_ready:
+            warnings.append("row group split is not suitable for L1 model comparison")
+
+        return {
+            "dataset_path": str(resolved_dataset_path.resolve()),
+            "file_count": len(files),
+            "total_row_groups": split_plan.total_row_groups,
+            "total_rows": int(sum(rows for _path, _index, rows in rg_info)),
+            "row_group_split": {
+                "train_row_groups": split_plan.train_row_groups,
+                "valid_row_groups": split_plan.valid_row_groups,
+                "train_row_group_range": list(split_plan.train_row_group_range),
+                "valid_row_group_range": list(split_plan.valid_row_group_range),
+                "train_rows": split_plan.train_rows,
+                "valid_rows": split_plan.valid_rows,
+                "reuse_train_for_valid": split_plan.reuse_train_for_valid,
+                "is_disjoint": split_plan.is_disjoint,
+                "is_l1_ready": split_plan.is_l1_ready,
+            },
+            "warnings": warnings,
+        }
 
     def infer(self, request: InferRequest) -> Mapping[str, Any]:
         checkpoint_root = Path(os.environ.get("MODEL_OUTPUT_PATH", "")).expanduser()
@@ -297,18 +315,12 @@ class PCVRExperiment:
         config: dict[str, Any],
         *,
         config_key: str,
-        flag_names: tuple[str, ...],
         minimum: int,
-    ) -> tuple[int | None, str | None]:
-        configured_value = _coerce_optional_int(config.get(config_key))
-        if configured_value is not None and configured_value >= minimum:
-            return configured_value, "train_config"
-
-        default_arg_value = _coerce_optional_int(_read_flag_value(self.default_train_args, flag_names))
-        if default_arg_value is not None and default_arg_value >= minimum:
-            return default_arg_value, "experiment_default_train_args"
-
-        return None, None
+    ) -> tuple[int, str]:
+        configured_value = _coerce_optional_int(_required_config_value(config, config_key))
+        if configured_value is None or configured_value < minimum:
+            raise ValueError(f"PCVR train_config key {config_key!r} must be >= {minimum}, got {config.get(config_key)!r}")
+        return configured_value, "train_config"
 
     def _resolve_prediction_runtime_settings(
         self,
@@ -321,12 +333,10 @@ class PCVRExperiment:
             configured_batch_size, configured_batch_size_source = self._configured_infer_runtime_value(
                 config,
                 config_key="batch_size",
-                flag_names=("--batch_size", "--batch-size"),
                 minimum=1,
             )
-            if configured_batch_size is not None and configured_batch_size_source is not None:
-                batch_size = configured_batch_size
-                batch_size_source = configured_batch_size_source
+            batch_size = configured_batch_size
+            batch_size_source = configured_batch_size_source
 
         num_workers = int(request.num_workers)
         num_workers_source = "request" if request.num_workers != _INFER_REQUEST_DEFAULT_NUM_WORKERS else "cli_default"
@@ -334,12 +344,10 @@ class PCVRExperiment:
             configured_num_workers, configured_num_workers_source = self._configured_infer_runtime_value(
                 config,
                 config_key="num_workers",
-                flag_names=("--num_workers", "--num-workers"),
                 minimum=0,
             )
-            if configured_num_workers is not None and configured_num_workers_source is not None:
-                num_workers = configured_num_workers
-                num_workers_source = configured_num_workers_source
+            num_workers = configured_num_workers
+            num_workers_source = configured_num_workers_source
 
         return batch_size, batch_size_source, num_workers, num_workers_source
 
@@ -350,28 +358,20 @@ class PCVRExperiment:
     ) -> tuple[int, str, int, str]:
         return self._resolve_prediction_runtime_settings(request, config)
 
-    def _configured_runtime_flag(
+    def _configured_runtime_bool(
         self,
         request_value: bool | None,
         config: dict[str, Any],
         *,
         config_key: str,
-        enabled_flags: tuple[str, ...],
-        disabled_flags: tuple[str, ...],
-        default: bool,
     ) -> tuple[bool, str]:
         if request_value is not None:
             return bool(request_value), "request"
 
-        configured_value = config.get(config_key)
-        if isinstance(configured_value, bool):
-            return configured_value, "train_config"
-
-        default_arg_value = _read_bool_flag_value(self.default_train_args, enabled_flags, disabled_flags)
-        if default_arg_value is not None:
-            return default_arg_value, "experiment_default_train_args"
-
-        return default, "default"
+        configured_value = _required_config_value(config, config_key)
+        if not isinstance(configured_value, bool):
+            raise TypeError(f"PCVR train_config key {config_key!r} must be bool, got {type(configured_value).__name__}")
+        return configured_value, "train_config"
 
     def _configured_runtime_string(
         self,
@@ -379,49 +379,34 @@ class PCVRExperiment:
         config: dict[str, Any],
         *,
         config_key: str,
-        flag_names: tuple[str, ...],
-        default: str,
     ) -> tuple[str, str]:
         if request_value not in (None, ""):
             return normalize_amp_dtype(request_value), "request"
 
-        configured_value = config.get(config_key)
-        if isinstance(configured_value, str) and configured_value.strip():
-            return normalize_amp_dtype(configured_value), "train_config"
-
-        default_arg_value = _read_flag_value(self.default_train_args, flag_names)
-        if default_arg_value not in (None, ""):
-            return normalize_amp_dtype(default_arg_value), "experiment_default_train_args"
-
-        return normalize_amp_dtype(default), "default"
+        configured_value = _required_config_value(config, config_key)
+        if not isinstance(configured_value, str) or not configured_value.strip():
+            raise TypeError(f"PCVR train_config key {config_key!r} must be a non-empty string")
+        return normalize_amp_dtype(configured_value), "train_config"
 
     def _resolve_prediction_runtime_execution(
         self,
         request: EvalRequest | InferRequest,
         config: dict[str, Any],
     ) -> tuple[RuntimeExecutionConfig, str, str, str]:
-        amp, amp_source = self._configured_runtime_flag(
+        amp, amp_source = self._configured_runtime_bool(
             getattr(request, "amp", None),
             config,
             config_key="amp",
-            enabled_flags=("--amp",),
-            disabled_flags=("--no-amp",),
-            default=False,
         )
         amp_dtype, amp_dtype_source = self._configured_runtime_string(
             getattr(request, "amp_dtype", None),
             config,
             config_key="amp_dtype",
-            flag_names=("--amp_dtype", "--amp-dtype"),
-            default="bfloat16",
         )
-        compile_enabled, compile_source = self._configured_runtime_flag(
+        compile_enabled, compile_source = self._configured_runtime_bool(
             getattr(request, "compile", None),
             config,
             config_key="compile",
-            enabled_flags=("--compile",),
-            disabled_flags=("--no-compile",),
-            default=False,
         )
         return RuntimeExecutionConfig(amp=amp, amp_dtype=amp_dtype, compile=compile_enabled), amp_source, amp_dtype_source, compile_source
 
@@ -442,7 +427,7 @@ class PCVRExperiment:
 
         resolved_schema_path = self._resolve_schema_path(dataset_path, schema_path, checkpoint_path.parent)
         resolved_config = config if config is not None else self._load_train_config(checkpoint_path.parent)
-        seq_max_lens = parse_seq_max_lens(str(resolved_config.get("seq_max_lens", "")))
+        seq_max_lens = parse_seq_max_lens(str(resolved_config["seq_max_lens"]))
         dataset = pcvr_data.PCVRParquetDataset(
             parquet_path=str(dataset_path.expanduser().resolve()),
             schema_path=str(resolved_schema_path),
@@ -548,11 +533,14 @@ class PCVRExperiment:
         return {"labels": labels, "probabilities": probabilities, "records": records}
 
     def _load_train_config(self, checkpoint_dir: Path) -> dict[str, Any]:
-        config = dict(DEFAULT_PCVR_MODEL_CONFIG)
         config_path = checkpoint_dir / "train_config.json"
-        if config_path.exists():
-            stored_config = read_json(config_path)
-            config.update(stored_config)
+        if not config_path.exists():
+            raise FileNotFoundError(f"PCVR train_config.json not found in checkpoint directory: {checkpoint_dir}")
+        config = read_json(config_path)
+        missing_keys = sorted(REQUIRED_PCVR_TRAIN_CONFIG_KEYS - set(config))
+        if missing_keys:
+            joined = ", ".join(missing_keys)
+            raise KeyError(f"PCVR train_config.json is missing required key(s): {joined}")
         return config
 
     def _resolve_schema_path(self, dataset_path: Path, schema_path: Path | None, checkpoint_dir: Path) -> Path:

--- a/src/taac2026/infrastructure/pcvr/protocol.py
+++ b/src/taac2026/infrastructure/pcvr/protocol.py
@@ -2,38 +2,13 @@
 
 from __future__ import annotations
 
+import inspect
 from pathlib import Path
 from typing import Any
 
 import torch
 
 from taac2026.infrastructure.io.files import read_json
-
-
-DEFAULT_PCVR_MODEL_CONFIG: dict[str, Any] = {
-    "d_model": 64,
-    "emb_dim": 64,
-    "num_queries": 2,
-    "num_blocks": 2,
-    "num_heads": 4,
-    "seq_encoder_type": "transformer",
-    "hidden_mult": 4,
-    "dropout_rate": 0.01,
-    "seq_top_k": 50,
-    "seq_causal": False,
-    "action_num": 1,
-    "use_time_buckets": True,
-    "rank_mixer_mode": "full",
-    "use_rope": False,
-    "rope_base": 10000.0,
-    "emb_skip_threshold": 1000000,
-    "seq_id_threshold": 10000,
-    "ns_tokenizer_type": "rankmixer",
-    "user_ns_tokens": 5,
-    "item_ns_tokens": 2,
-    "seq_max_lens": "seq_a:256,seq_b:256,seq_c:512,seq_d:512",
-    "ns_groups_json": "ns_groups.json",
-}
 
 
 def parse_seq_max_lens(value: str) -> dict[str, int]:
@@ -89,7 +64,7 @@ def resolve_ns_groups_path(value: str, package_dir: Path, checkpoint_dir: Path) 
 
 
 def load_ns_groups(dataset: Any, config: dict[str, Any], package_dir: Path, checkpoint_dir: Path) -> tuple[list[list[int]], list[list[int]]]:
-    ns_groups_path = resolve_ns_groups_path(str(config.get("ns_groups_json", "")), package_dir, checkpoint_dir)
+    ns_groups_path = resolve_ns_groups_path(str(config["ns_groups_json"]), package_dir, checkpoint_dir)
     if ns_groups_path is None:
         return (
             [[index] for index in range(len(dataset.user_int_schema.entries))],
@@ -114,7 +89,7 @@ def load_ns_groups(dataset: Any, config: dict[str, Any], package_dir: Path, chec
 
 
 def num_time_buckets(config: dict[str, Any], data_module: Any) -> int:
-    if not bool(config.get("use_time_buckets", True)):
+    if not bool(config["use_time_buckets"]):
         return 0
     return int(data_module.NUM_TIME_BUCKETS)
 
@@ -133,7 +108,7 @@ def build_pcvr_model(
     user_int_feature_specs = build_feature_specs(dataset.user_int_schema, dataset.user_int_vocab_sizes)
     item_int_feature_specs = build_feature_specs(dataset.item_int_schema, dataset.item_int_vocab_sizes)
     model_class = getattr(model_module, model_class_name)
-    return model_class(
+    model_kwargs = dict(
         user_int_feature_specs=user_int_feature_specs,
         item_int_feature_specs=item_int_feature_specs,
         user_dense_dim=dataset.user_dense_schema.total_dim,
@@ -162,6 +137,17 @@ def build_pcvr_model(
         user_ns_tokens=int(config["user_ns_tokens"]),
         item_ns_tokens=int(config["item_ns_tokens"]),
     )
+    model_signature = inspect.signature(model_class)
+    for key in (
+        "symbiosis_use_user_item_graph",
+        "symbiosis_use_fourier_time",
+        "symbiosis_use_context_exchange",
+        "symbiosis_use_multi_scale",
+        "symbiosis_use_domain_gate",
+    ):
+        if key in model_signature.parameters:
+            model_kwargs[key] = bool(config[key])
+    return model_class(**model_kwargs)
 
 
 def batch_to_model_input(batch: dict[str, Any], model_input_type: Any, device: torch.device) -> Any:

--- a/src/taac2026/infrastructure/pcvr/trainer.py
+++ b/src/taac2026/infrastructure/pcvr/trainer.py
@@ -18,15 +18,17 @@ from sklearn.metrics import roc_auc_score
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
+from taac2026.domain.metrics import binary_score_diagnostics
 from taac2026.infrastructure.checkpoints import build_checkpoint_dir_name, write_checkpoint_sidecars
 from taac2026.infrastructure.pcvr.protocol import batch_to_model_input
 from taac2026.infrastructure.pcvr.tensors import sigmoid_probabilities_numpy
 from taac2026.infrastructure.training.runtime import (
+    BinaryClassificationLossConfig,
     EarlyStopping,
     RuntimeExecutionConfig,
+    compute_binary_classification_loss,
     create_grad_scaler,
     maybe_compile_callable,
-    sigmoid_focal_loss,
 )
 
 
@@ -139,9 +141,14 @@ class PCVRPointwiseTrainer:
             label="PCVR trainer predict",
         )
         self.grad_scaler = create_grad_scaler(self.runtime_execution, self.device)
-        self.loss_type = loss_type
-        self.focal_alpha = focal_alpha
-        self.focal_gamma = focal_gamma
+        self.loss_config = BinaryClassificationLossConfig(
+            loss_type=loss_type,
+            focal_alpha=focal_alpha,
+            focal_gamma=focal_gamma,
+        )
+        self.loss_type = self.loss_config.loss_type
+        self.focal_alpha = self.loss_config.focal_alpha
+        self.focal_gamma = self.loss_config.focal_gamma
         self.reinit_sparse_after_epoch = reinit_sparse_after_epoch
         self.reinit_cardinality_threshold = reinit_cardinality_threshold
         self.sparse_lr = sparse_lr
@@ -149,13 +156,14 @@ class PCVRPointwiseTrainer:
         self.ckpt_params = ckpt_params or {}
         self.eval_every_n_steps = eval_every_n_steps
         self.train_config = train_config
+        self.last_eval_diagnostics: dict[str, float | int] = {}
 
         logging.info(
             "PCVRPointwiseTrainer loss_type=%s, focal_alpha=%s, focal_gamma=%s, "
             "reinit_sparse_after_epoch=%s",
-            loss_type,
-            focal_alpha,
-            focal_gamma,
+            self.loss_type,
+            self.focal_alpha,
+            self.focal_gamma,
             reinit_sparse_after_epoch,
         )
         logging.info("PCVRPointwiseTrainer runtime: %s", self.runtime_execution.summary(self.device))
@@ -214,6 +222,7 @@ class PCVRPointwiseTrainer:
             self.early_stopping(val_auc, self.model, {
                 "best_val_AUC": val_auc,
                 "best_val_logloss": val_logloss,
+                "best_val_score_diagnostics": self.last_eval_diagnostics,
             })
             return
 
@@ -224,6 +233,7 @@ class PCVRPointwiseTrainer:
         self.early_stopping(val_auc, self.model, {
             "best_val_AUC": val_auc,
             "best_val_logloss": val_logloss,
+            "best_val_score_diagnostics": self.last_eval_diagnostics,
         })
 
         if self.early_stopping.best_score != old_best and Path(self.early_stopping.checkpoint_path).exists():
@@ -251,6 +261,14 @@ class PCVRPointwiseTrainer:
         if loss is not None:
             message = f"{message} | loss={loss:.4f}"
         logging.info(message)
+
+    def _write_eval_diagnostics(self, total_step: int) -> None:
+        if self.writer is None:
+            return
+        for name, value in self.last_eval_diagnostics.items():
+            numeric_value = float(value)
+            if np.isfinite(numeric_value):
+                self.writer.add_scalar(f"Diagnostics/valid/{name}", numeric_value, total_step)
 
     def train(self) -> None:
         print("Start training (PCVR pointwise)")
@@ -302,6 +320,7 @@ class PCVRPointwiseTrainer:
                     if self.writer:
                         self.writer.add_scalar("AUC/valid", val_auc, total_step)
                         self.writer.add_scalar("LogLoss/valid", val_logloss, total_step)
+                        self._write_eval_diagnostics(total_step)
 
                     self._handle_validation_result(total_step, val_auc, val_logloss)
 
@@ -323,6 +342,7 @@ class PCVRPointwiseTrainer:
             if self.writer:
                 self.writer.add_scalar("AUC/valid", val_auc, total_step)
                 self.writer.add_scalar("LogLoss/valid", val_logloss, total_step)
+                self._write_eval_diagnostics(total_step)
 
             self._handle_validation_result(total_step, val_auc, val_logloss)
 
@@ -368,11 +388,7 @@ class PCVRPointwiseTrainer:
         model_input = self._make_model_input(device_batch)
         with self.runtime_execution.autocast_context(self.device):
             logits = self.forward_model(model_input).squeeze(-1)
-
-            if self.loss_type == "focal":
-                loss = sigmoid_focal_loss(logits, label, alpha=self.focal_alpha, gamma=self.focal_gamma)
-            else:
-                loss = F.binary_cross_entropy_with_logits(logits, label)
+            loss = compute_binary_classification_loss(logits, label, self.loss_config)
 
         if self.grad_scaler is not None:
             self.grad_scaler.scale(loss).backward()
@@ -457,6 +473,17 @@ class PCVRPointwiseTrainer:
             logloss = F.binary_cross_entropy_with_logits(valid_logits, valid_labels.float()).item()
         else:
             logloss = float("inf")
+
+        self.last_eval_diagnostics = binary_score_diagnostics(labels_np, probabilities)
+        logging.info(
+            "Validation score diagnostics | pos=%s neg=%s pos_mean=%.6f neg_mean=%.6f margin=%.6f score_std=%.6f",
+            self.last_eval_diagnostics["positive_count"],
+            self.last_eval_diagnostics["negative_count"],
+            self.last_eval_diagnostics["positive_score_mean"],
+            self.last_eval_diagnostics["negative_score_mean"],
+            self.last_eval_diagnostics["score_margin_mean"],
+            self.last_eval_diagnostics["score_std"],
+        )
 
         return auc, logloss
 

--- a/src/taac2026/infrastructure/pcvr/training.py
+++ b/src/taac2026/infrastructure/pcvr/training.py
@@ -12,6 +12,10 @@ from typing import Any
 import torch
 
 import taac2026.infrastructure.pcvr.data as pcvr_data
+from taac2026.infrastructure.pcvr.config import (
+    DEFAULT_PCVR_TRAIN_CONFIG,
+    PCVRTrainConfig,
+)
 from taac2026.infrastructure.pcvr.protocol import (
     build_pcvr_model,
     load_ns_groups,
@@ -22,6 +26,7 @@ from taac2026.infrastructure.pcvr.protocol import (
 from taac2026.infrastructure.pcvr.trainer import PCVRPointwiseTrainer
 from taac2026.infrastructure.training.runtime import (
     AMP_DTYPE_CHOICES,
+    BINARY_LOSS_TYPE_CHOICES,
     EarlyStopping,
     RuntimeExecutionConfig,
     create_logger,
@@ -33,76 +38,184 @@ def parse_pcvr_train_args(
     argv: Sequence[str] | None = None,
     *,
     package_dir: Path,
+    defaults: PCVRTrainConfig = DEFAULT_PCVR_TRAIN_CONFIG,
 ) -> argparse.Namespace:
+    default_values = defaults.to_flat_dict()
     parser = argparse.ArgumentParser(description="Train a PCVR experiment")
 
     parser.add_argument("--data_dir", "--data-dir", dest="data_dir", default=None)
-    parser.add_argument("--schema_path", "--schema-path", dest="schema_path", default=None)
+    parser.add_argument(
+        "--schema_path", "--schema-path", dest="schema_path", default=None
+    )
     parser.add_argument("--ckpt_dir", "--ckpt-dir", dest="ckpt_dir", default=None)
     parser.add_argument("--log_dir", "--log-dir", dest="log_dir", default=None)
-    parser.add_argument("--tf_events_dir", "--tf-events-dir", dest="tf_events_dir", default=None)
+    parser.add_argument(
+        "--tf_events_dir", "--tf-events-dir", dest="tf_events_dir", default=None
+    )
 
-    parser.add_argument("--batch_size", type=int, default=256)
-    parser.add_argument("--lr", type=float, default=1e-4)
-    parser.add_argument("--num_epochs", type=int, default=999)
-    parser.add_argument("--patience", type=int, default=5)
-    parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
-    parser.add_argument("--amp", action=argparse.BooleanOptionalAction, default=False)
+    parser.add_argument("--batch_size", type=int, default=default_values["batch_size"])
+    parser.add_argument("--lr", type=float, default=default_values["lr"])
+    parser.add_argument("--num_epochs", type=int, default=default_values["num_epochs"])
+    parser.add_argument("--patience", type=int, default=default_values["patience"])
+    parser.add_argument("--seed", type=int, default=default_values["seed"])
+    parser.add_argument(
+        "--device",
+        default=default_values["device"]
+        or ("cuda" if torch.cuda.is_available() else "cpu"),
+    )
+    parser.add_argument(
+        "--amp", action=argparse.BooleanOptionalAction, default=default_values["amp"]
+    )
     parser.add_argument(
         "--amp_dtype",
         "--amp-dtype",
         dest="amp_dtype",
-        default="bfloat16",
+        default=default_values["amp_dtype"],
         choices=AMP_DTYPE_CHOICES,
     )
-    parser.add_argument("--compile", action=argparse.BooleanOptionalAction, default=False)
+    parser.add_argument(
+        "--compile",
+        action=argparse.BooleanOptionalAction,
+        default=default_values["compile"],
+    )
 
-    parser.add_argument("--num_workers", type=int, default=16)
-    parser.add_argument("--buffer_batches", type=int, default=20)
-    parser.add_argument("--train_ratio", type=float, default=1.0)
-    parser.add_argument("--valid_ratio", type=float, default=0.1)
-    parser.add_argument("--eval_every_n_steps", type=int, default=0)
-    parser.add_argument("--seq_max_lens", default="seq_a:256,seq_b:256,seq_c:512,seq_d:512")
+    parser.add_argument(
+        "--num_workers", type=int, default=default_values["num_workers"]
+    )
+    parser.add_argument(
+        "--buffer_batches", type=int, default=default_values["buffer_batches"]
+    )
+    parser.add_argument(
+        "--train_ratio", type=float, default=default_values["train_ratio"]
+    )
+    parser.add_argument(
+        "--valid_ratio", type=float, default=default_values["valid_ratio"]
+    )
+    parser.add_argument(
+        "--eval_every_n_steps", type=int, default=default_values["eval_every_n_steps"]
+    )
+    parser.add_argument("--seq_max_lens", default=default_values["seq_max_lens"])
 
-    parser.add_argument("--d_model", type=int, default=64)
-    parser.add_argument("--emb_dim", type=int, default=64)
-    parser.add_argument("--num_queries", type=int, default=1)
-    parser.add_argument("--num_blocks", type=int, default=2)
-    parser.add_argument("--num_heads", type=int, default=4)
+    parser.add_argument("--d_model", type=int, default=default_values["d_model"])
+    parser.add_argument("--emb_dim", type=int, default=default_values["emb_dim"])
+    parser.add_argument(
+        "--num_queries", type=int, default=default_values["num_queries"]
+    )
+    parser.add_argument("--num_blocks", type=int, default=default_values["num_blocks"])
+    parser.add_argument("--num_heads", type=int, default=default_values["num_heads"])
     parser.add_argument(
         "--seq_encoder_type",
-        default="transformer",
+        default=default_values["seq_encoder_type"],
         choices=["swiglu", "transformer", "longer"],
     )
-    parser.add_argument("--hidden_mult", type=int, default=4)
-    parser.add_argument("--dropout_rate", type=float, default=0.01)
-    parser.add_argument("--seq_top_k", type=int, default=50)
-    parser.add_argument("--seq_causal", action="store_true", default=False)
-    parser.add_argument("--action_num", type=int, default=1)
-    parser.add_argument("--use_time_buckets", action="store_true", default=True)
-    parser.add_argument("--no_time_buckets", dest="use_time_buckets", action="store_false")
-    parser.add_argument("--rank_mixer_mode", default="full", choices=["full", "ffn_only", "none"])
-    parser.add_argument("--use_rope", action="store_true", default=False)
-    parser.add_argument("--rope_base", type=float, default=10000.0)
+    parser.add_argument(
+        "--hidden_mult", type=int, default=default_values["hidden_mult"]
+    )
+    parser.add_argument(
+        "--dropout_rate", type=float, default=default_values["dropout_rate"]
+    )
+    parser.add_argument("--seq_top_k", type=int, default=default_values["seq_top_k"])
+    parser.add_argument(
+        "--seq_causal", action="store_true", default=default_values["seq_causal"]
+    )
+    parser.add_argument("--action_num", type=int, default=default_values["action_num"])
+    parser.add_argument(
+        "--use_time_buckets",
+        action="store_true",
+        default=default_values["use_time_buckets"],
+    )
+    parser.add_argument(
+        "--no_time_buckets", dest="use_time_buckets", action="store_false"
+    )
+    parser.add_argument(
+        "--rank_mixer_mode",
+        default=default_values["rank_mixer_mode"],
+        choices=["full", "ffn_only", "none"],
+    )
+    parser.add_argument(
+        "--use_rope", action="store_true", default=default_values["use_rope"]
+    )
+    parser.add_argument("--rope_base", type=float, default=default_values["rope_base"])
 
-    parser.add_argument("--loss_type", default="bce", choices=["bce", "focal"])
-    parser.add_argument("--focal_alpha", type=float, default=0.1)
-    parser.add_argument("--focal_gamma", type=float, default=2.0)
+    parser.add_argument(
+        "--loss_type",
+        default=default_values["loss_type"],
+        choices=BINARY_LOSS_TYPE_CHOICES,
+    )
+    parser.add_argument(
+        "--focal_alpha", type=float, default=default_values["focal_alpha"]
+    )
+    parser.add_argument(
+        "--focal_gamma", type=float, default=default_values["focal_gamma"]
+    )
 
-    parser.add_argument("--sparse_lr", type=float, default=0.05)
-    parser.add_argument("--sparse_weight_decay", type=float, default=0.0)
-    parser.add_argument("--reinit_sparse_after_epoch", type=int, default=1)
-    parser.add_argument("--reinit_cardinality_threshold", type=int, default=0)
+    parser.add_argument("--sparse_lr", type=float, default=default_values["sparse_lr"])
+    parser.add_argument(
+        "--sparse_weight_decay",
+        type=float,
+        default=default_values["sparse_weight_decay"],
+    )
+    parser.add_argument(
+        "--reinit_sparse_after_epoch",
+        type=int,
+        default=default_values["reinit_sparse_after_epoch"],
+    )
+    parser.add_argument(
+        "--reinit_cardinality_threshold",
+        type=int,
+        default=default_values["reinit_cardinality_threshold"],
+    )
 
-    parser.add_argument("--emb_skip_threshold", type=int, default=0)
-    parser.add_argument("--seq_id_threshold", type=int, default=10000)
+    parser.add_argument(
+        "--emb_skip_threshold", type=int, default=default_values["emb_skip_threshold"]
+    )
+    parser.add_argument(
+        "--seq_id_threshold", type=int, default=default_values["seq_id_threshold"]
+    )
 
-    default_ns_groups = package_dir / "ns_groups.json"
-    parser.add_argument("--ns_groups_json", default=str(default_ns_groups))
-    parser.add_argument("--ns_tokenizer_type", default="rankmixer", choices=["group", "rankmixer"])
-    parser.add_argument("--user_ns_tokens", type=int, default=0)
-    parser.add_argument("--item_ns_tokens", type=int, default=0)
+    parser.add_argument("--ns_groups_json", default=default_values["ns_groups_json"])
+    parser.add_argument(
+        "--ns_tokenizer_type",
+        default=default_values["ns_tokenizer_type"],
+        choices=["group", "rankmixer"],
+    )
+    parser.add_argument(
+        "--user_ns_tokens", type=int, default=default_values["user_ns_tokens"]
+    )
+    parser.add_argument(
+        "--item_ns_tokens", type=int, default=default_values["item_ns_tokens"]
+    )
+
+    parser.add_argument(
+        "--symbiosis_use_user_item_graph",
+        "--symbiosis-use-user-item-graph",
+        action=argparse.BooleanOptionalAction,
+        default=default_values["symbiosis_use_user_item_graph"],
+    )
+    parser.add_argument(
+        "--symbiosis_use_fourier_time",
+        "--symbiosis-use-fourier-time",
+        action=argparse.BooleanOptionalAction,
+        default=default_values["symbiosis_use_fourier_time"],
+    )
+    parser.add_argument(
+        "--symbiosis_use_context_exchange",
+        "--symbiosis-use-context-exchange",
+        action=argparse.BooleanOptionalAction,
+        default=default_values["symbiosis_use_context_exchange"],
+    )
+    parser.add_argument(
+        "--symbiosis_use_multi_scale",
+        "--symbiosis-use-multi-scale",
+        action=argparse.BooleanOptionalAction,
+        default=default_values["symbiosis_use_multi_scale"],
+    )
+    parser.add_argument(
+        "--symbiosis_use_domain_gate",
+        "--symbiosis-use-domain-gate",
+        action=argparse.BooleanOptionalAction,
+        default=default_values["symbiosis_use_domain_gate"],
+    )
 
     args = parser.parse_args(argv)
     args.data_dir = os.environ.get("TRAIN_DATA_PATH", args.data_dir)
@@ -124,9 +237,10 @@ def train_pcvr_model(
     model_module: Any,
     model_class_name: str,
     package_dir: Path,
+    defaults: PCVRTrainConfig = DEFAULT_PCVR_TRAIN_CONFIG,
     argv: Sequence[str] | None = None,
 ) -> dict[str, Any]:
-    args = parse_pcvr_train_args(argv, package_dir=package_dir)
+    args = parse_pcvr_train_args(argv, package_dir=package_dir, defaults=defaults)
     data_dir = _required_path(args.data_dir, "data_dir")
     ckpt_dir = _required_path(args.ckpt_dir, "ckpt_dir")
     log_dir = _required_path(args.log_dir, "log_dir")
@@ -139,13 +253,17 @@ def train_pcvr_model(
     set_seed(args.seed)
     create_logger(log_dir / "train.log")
     config = vars(args).copy()
+    data_pipeline_config = defaults.data_pipeline
+    config.update(data_pipeline_config.to_flat_dict())
     logging.info("Args: %s", config)
     runtime_execution = RuntimeExecutionConfig(
         amp=bool(args.amp),
         amp_dtype=str(args.amp_dtype),
         compile=bool(args.compile),
     )
-    logging.info("Resolved PCVR training runtime: %s", runtime_execution.summary(args.device))
+    logging.info(
+        "Resolved PCVR training runtime: %s", runtime_execution.summary(args.device)
+    )
 
     from torch.utils.tensorboard import SummaryWriter
 
@@ -172,9 +290,12 @@ def train_pcvr_model(
             buffer_batches=args.buffer_batches,
             seed=args.seed,
             seq_max_lens=seq_max_lens,
+            data_pipeline_config=data_pipeline_config,
         )
 
-        user_ns_groups, item_ns_groups = load_ns_groups(pcvr_dataset, config, package_dir, ckpt_dir)
+        user_ns_groups, item_ns_groups = load_ns_groups(
+            pcvr_dataset, config, package_dir, ckpt_dir
+        )
         logging.info("User NS groups: %s", user_ns_groups)
         logging.info("Item NS groups: %s", item_ns_groups)
 
@@ -212,7 +333,9 @@ def train_pcvr_model(
             "head": args.num_heads,
             "hidden": args.d_model,
         }
-        resolved_ns_groups_path = resolve_ns_groups_path(str(args.ns_groups_json), package_dir, ckpt_dir)
+        resolved_ns_groups_path = resolve_ns_groups_path(
+            str(args.ns_groups_json), package_dir, ckpt_dir
+        )
         trainer = PCVRPointwiseTrainer(
             model=model,
             model_input_type=model_module.ModelInput,

--- a/src/taac2026/infrastructure/training/runtime.py
+++ b/src/taac2026/infrastructure/training/runtime.py
@@ -20,6 +20,7 @@ import torch.nn.functional as F
 
 
 AMP_DTYPE_CHOICES: tuple[str, ...] = ("bfloat16", "float16")
+BINARY_LOSS_TYPE_CHOICES: tuple[str, ...] = ("bce", "focal")
 _AMP_DTYPE_ALIASES = {
     "bf16": "bfloat16",
     "bfloat16": "bfloat16",
@@ -78,6 +79,33 @@ class RuntimeExecutionConfig:
             f"amp={self.amp} (effective={self.amp_enabled_for(device)}), "
             f"amp_dtype={self.normalized_amp_dtype()}, compile={self.compile}"
         )
+
+
+@dataclass(frozen=True, slots=True)
+class BinaryClassificationLossConfig:
+    loss_type: str = "bce"
+    focal_alpha: float = 0.1
+    focal_gamma: float = 2.0
+
+    def __post_init__(self) -> None:
+        normalized_loss_type = str(self.loss_type).strip().lower()
+        if normalized_loss_type not in BINARY_LOSS_TYPE_CHOICES:
+            raise ValueError(f"unsupported loss_type: {self.loss_type}")
+
+        focal_alpha = float(self.focal_alpha)
+        if not 0.0 <= focal_alpha <= 1.0:
+            raise ValueError(f"focal_alpha must be between 0 and 1, got {self.focal_alpha}")
+
+        focal_gamma = float(self.focal_gamma)
+        if focal_gamma < 0.0:
+            raise ValueError(f"focal_gamma must be >= 0, got {self.focal_gamma}")
+
+        object.__setattr__(self, "loss_type", normalized_loss_type)
+        object.__setattr__(self, "focal_alpha", focal_alpha)
+        object.__setattr__(self, "focal_gamma", focal_gamma)
+
+
+DEFAULT_BINARY_CLASSIFICATION_LOSS_CONFIG = BinaryClassificationLossConfig()
 
 
 def create_grad_scaler(
@@ -235,3 +263,23 @@ def sigmoid_focal_loss(
     if reduction == "sum":
         return loss.sum()
     return loss
+
+
+def compute_binary_classification_loss(
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+    loss_config: BinaryClassificationLossConfig | None = None,
+    reduction: str = "mean",
+) -> torch.Tensor:
+    """Compute the shared binary classification loss from raw logits."""
+
+    resolved_loss_config = loss_config or DEFAULT_BINARY_CLASSIFICATION_LOSS_CONFIG
+    if resolved_loss_config.loss_type == "focal":
+        return sigmoid_focal_loss(
+            logits,
+            targets,
+            alpha=resolved_loss_config.focal_alpha,
+            gamma=resolved_loss_config.focal_gamma,
+            reduction=reduction,
+        )
+    return F.binary_cross_entropy_with_logits(logits, targets, reduction=reduction)

--- a/tests/unit/test_experiment_discovery.py
+++ b/tests/unit/test_experiment_discovery.py
@@ -12,9 +12,10 @@ def _write_minimal_pcvr_experiment(package_dir: Path, *, experiment_name: str, m
     (package_dir / "__init__.py").write_text(
         "from pathlib import Path\n"
         "\n"
+        "from taac2026.infrastructure.pcvr.config import PCVRNSConfig, PCVRTrainConfig\n"
         "from taac2026.infrastructure.pcvr.experiment import PCVRExperiment\n"
         "\n"
-        f"EXPERIMENT = PCVRExperiment(name={experiment_name!r}, package_dir=Path(__file__).resolve().parent, model_class_name={model_class_name!r}, default_train_args=(\"--ns_groups_json\", \"ns_groups.json\"))\n",
+        f"EXPERIMENT = PCVRExperiment(name={experiment_name!r}, package_dir=Path(__file__).resolve().parent, model_class_name={model_class_name!r}, train_defaults=PCVRTrainConfig(ns=PCVRNSConfig(groups_json=\"ns_groups.json\")))\n",
         encoding="utf-8",
     )
     (package_dir / "model.py").write_text(

--- a/tests/unit/test_experiment_packages.py
+++ b/tests/unit/test_experiment_packages.py
@@ -42,7 +42,7 @@ def _sample_model_input(model_module):
     )
 
 
-def _make_model(experiment_case, model_module):
+def _make_model(experiment_case, model_module, overrides=None):
     model_class = getattr(model_module, experiment_case.model_class)
     model_kwargs = dict(
         user_int_feature_specs=[(8, 0, 1), (7, 1, 2)],
@@ -64,6 +64,8 @@ def _make_model(experiment_case, model_module):
         user_ns_tokens=2,
         item_ns_tokens=1,
     )
+    if overrides:
+        model_kwargs.update(overrides)
     try:
         return model_class(**model_kwargs)
     except ValueError as error:
@@ -77,16 +79,16 @@ def _make_model(experiment_case, model_module):
 @pytest.mark.parametrize("experiment_case", EXPERIMENT_CASES, ids=lambda case: case.path)
 def test_discovered_experiment_packages_load(experiment_case) -> None:
     experiment = load_experiment_package(experiment_case.path)
+    train_defaults = experiment.train_defaults.to_flat_dict()
 
     assert experiment.name == experiment_case.name
     assert experiment.package_dir == experiment_case.package_dir
-    assert experiment.default_train_args
+    assert experiment.train_defaults is not None
     assert experiment.metadata["kind"] == "pcvr"
     assert experiment.metadata["model_class"] == experiment_case.model_class
     assert (experiment.package_dir / "ns_groups.json").exists()
-    assert "--ns_groups_json" in experiment.default_train_args
-    assert "ns_groups.json" in experiment.default_train_args
-    assert "--num_hyformer_blocks" not in experiment.default_train_args
+    assert train_defaults["ns_groups_json"] == "ns_groups.json"
+    assert "num_hyformer_blocks" not in train_defaults
 
 
 @pytest.mark.parametrize("experiment_case", EXPERIMENT_CASES, ids=lambda case: case.path)
@@ -116,11 +118,11 @@ def test_discovered_experiment_models_forward_and_predict(experiment_case) -> No
 
 def test_symbiosis_enables_amp_and_compile_by_default() -> None:
     experiment = load_experiment_package("config/symbiosis")
+    train_defaults = experiment.train_defaults.to_flat_dict()
 
-    assert "--amp" in experiment.default_train_args
-    assert "--amp-dtype" in experiment.default_train_args
-    assert "bfloat16" in experiment.default_train_args
-    assert "--compile" in experiment.default_train_args
+    assert train_defaults["amp"] is True
+    assert train_defaults["amp_dtype"] == "bfloat16"
+    assert train_defaults["compile"] is True
 
 
 def test_symbiosis_keeps_sequence_width_stable_for_compile() -> None:
@@ -238,3 +240,34 @@ def test_symbiosis_unified_attention_uses_context_bottleneck() -> None:
     assert logits.shape == (2, 1)
     assert observed_self_attention_lengths == [context_token_count]
     assert context_token_count < context_token_count + sequence_token_count
+
+
+def test_symbiosis_ablation_flags_disable_optional_modules() -> None:
+    experiment_case = get_experiment_case("config/symbiosis")
+    model_module = load_model_module(experiment_case)
+    model = _make_model(
+        experiment_case,
+        model_module,
+        overrides={
+            "symbiosis_use_user_item_graph": False,
+            "symbiosis_use_fourier_time": False,
+            "symbiosis_use_context_exchange": False,
+            "symbiosis_use_multi_scale": False,
+            "symbiosis_use_domain_gate": True,
+        },
+    )
+    model_input = _sample_model_input(model_module)
+
+    assert len(model.graph_blocks) == 0
+    assert len(model.context_blocks) == 0
+    assert model.symbiosis_use_fourier_time is False
+    assert model.symbiosis_use_multi_scale is False
+    assert all(block.use_domain_gate for block in model.unified_blocks)
+
+    logits = model(model_input)
+    predicted_logits, embeddings = model.predict(model_input)
+
+    assert logits.shape == (2, 1)
+    assert predicted_logits.shape == (2, 1)
+    assert embeddings.shape == (2, model.d_model)
+    assert torch.isfinite(logits).all()

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from taac2026.domain.metrics import binary_auc, binary_logloss, compute_classification_metrics
+from taac2026.domain.metrics import binary_auc, binary_auc_bootstrap_ci, binary_logloss, binary_score_diagnostics, compute_classification_metrics
 
 
 def test_binary_auc_counts_ties_as_half_credit() -> None:
@@ -34,4 +34,32 @@ def test_classification_metrics_accepts_logits() -> None:
     metrics = compute_classification_metrics(labels, logits)
 
     assert metrics["auc"] == pytest.approx(1.0)
+    assert metrics["auc_ci"]["low"] <= metrics["auc"] <= metrics["auc_ci"]["high"]
     assert metrics["sample_count"] == 4
+    assert metrics["score_diagnostics"]["positive_score_mean"] > metrics["score_diagnostics"]["negative_score_mean"]
+
+
+def test_binary_auc_bootstrap_ci_is_deterministic() -> None:
+    labels = np.asarray([0.0, 0.0, 1.0, 1.0], dtype=np.float32)
+    scores = np.asarray([0.1, 0.3, 0.7, 0.9], dtype=np.float32)
+
+    first = binary_auc_bootstrap_ci(labels, scores, samples=64, seed=7)
+    second = binary_auc_bootstrap_ci(labels, scores, samples=64, seed=7)
+
+    assert first == second
+    assert first["low"] <= 1.0 <= first["high"]
+
+
+def test_binary_score_diagnostics_reports_class_margins() -> None:
+    labels = np.asarray([0.0, 1.0, 1.0, 0.0], dtype=np.float32)
+    scores = np.asarray([0.1, 0.9, 0.7, 0.2], dtype=np.float32)
+
+    diagnostics = binary_score_diagnostics(labels, scores)
+
+    assert diagnostics["sample_count"] == 4
+    assert diagnostics["positive_count"] == 2
+    assert diagnostics["negative_count"] == 2
+    assert diagnostics["positive_rate"] == pytest.approx(0.5)
+    assert diagnostics["positive_score_mean"] == pytest.approx(0.8)
+    assert diagnostics["negative_score_mean"] == pytest.approx(0.15)
+    assert diagnostics["score_margin_mean"] == pytest.approx(0.65)

--- a/tests/unit/test_pcvr_data_augmentation.py
+++ b/tests/unit/test_pcvr_data_augmentation.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import torch
+
+from taac2026.infrastructure.pcvr.config import (
+    PCVRDataCacheConfig,
+    PCVRDataPipelineConfig,
+    PCVRDomainDropoutConfig,
+    PCVRFeatureMaskConfig,
+    PCVRSequenceCropConfig,
+)
+from taac2026.infrastructure.pcvr.data import PCVRParquetDataset
+from taac2026.infrastructure.pcvr.data_pipeline import (
+    PCVRDataPipeline,
+    PCVRDomainDropoutTransform,
+    PCVRFeatureMaskTransform,
+    PCVRMemoryBatchCache,
+    PCVRSequenceCropTransform,
+    build_pcvr_batch_transforms,
+)
+
+
+def _make_batch() -> dict[str, object]:
+    return {
+        "user_int_feats": torch.tensor([[1, 2], [3, 4]], dtype=torch.long),
+        "user_dense_feats": torch.tensor([[0.1], [0.2]], dtype=torch.float32),
+        "item_int_feats": torch.tensor([[5], [6]], dtype=torch.long),
+        "item_dense_feats": torch.zeros(2, 0, dtype=torch.float32),
+        "label": torch.tensor([1, 0], dtype=torch.long),
+        "timestamp": torch.tensor([100, 200], dtype=torch.long),
+        "user_id": ["u0", "u1"],
+        "_seq_domains": ["seq_a"],
+        "seq_a": torch.tensor(
+            [
+                [[1, 2, 3, 4]],
+                [[7, 8, 9, 0]],
+            ],
+            dtype=torch.long,
+        ),
+        "seq_a_len": torch.tensor([4, 3], dtype=torch.long),
+        "seq_a_time_bucket": torch.tensor(
+            [
+                [4, 3, 2, 1],
+                [3, 2, 1, 0],
+            ],
+            dtype=torch.long,
+        ),
+    }
+
+
+def _assert_tensor_dict_equal(
+    left: dict[str, object], right: dict[str, object]
+) -> None:
+    assert left.keys() == right.keys()
+    for key, left_value in left.items():
+        right_value = right[key]
+        if isinstance(left_value, torch.Tensor):
+            assert isinstance(right_value, torch.Tensor)
+            assert torch.equal(left_value, right_value), key
+        else:
+            assert left_value == right_value
+
+
+def test_empty_pipeline_config_builds_no_transforms() -> None:
+    config = PCVRDataPipelineConfig()
+
+    assert config.transform_names == ()
+    assert build_pcvr_batch_transforms(config) == ()
+
+
+def test_disabled_transform_preserves_batch_content() -> None:
+    batch = _make_batch()
+    transform = PCVRSequenceCropTransform(PCVRSequenceCropConfig(enabled=False))
+
+    augmented = transform(batch, generator=torch.Generator().manual_seed(1))
+
+    _assert_tensor_dict_equal(augmented, batch)
+    assert augmented is not batch
+
+
+def test_sequence_crop_expands_rows_and_keeps_metadata_aligned() -> None:
+    batch = _make_batch()
+    transform = PCVRSequenceCropTransform(
+        PCVRSequenceCropConfig(
+            views_per_row=2,
+            seq_window_mode="random_tail",
+            seq_window_min_len=2,
+        )
+    )
+
+    augmented = transform(batch, generator=torch.Generator().manual_seed(7))
+
+    assert augmented["label"].tolist() == [1, 1, 0, 0]
+    assert augmented["timestamp"].tolist() == [100, 100, 200, 200]
+    assert augmented["user_id"] == ["u0", "u0", "u1", "u1"]
+    assert augmented["user_int_feats"].shape == (4, 2)
+    assert augmented["seq_a"].shape == (4, 1, 4)
+    assert augmented["seq_a_len"].min().item() >= 2
+    assert augmented["seq_a_len"].max().item() <= 4
+    for row_index, length in enumerate(augmented["seq_a_len"].tolist()):
+        assert torch.equal(
+            augmented["seq_a"][row_index, :, length:],
+            torch.zeros(1, 4 - length, dtype=torch.long),
+        )
+        assert torch.equal(
+            augmented["seq_a_time_bucket"][row_index, length:],
+            torch.zeros(4 - length, dtype=torch.long),
+        )
+
+
+def test_domain_dropout_clears_sequence_tokens_lengths_and_time_buckets() -> None:
+    batch = _make_batch()
+    transform = PCVRDomainDropoutTransform(PCVRDomainDropoutConfig(probability=1.0))
+
+    augmented = transform(batch, generator=torch.Generator().manual_seed(3))
+
+    assert torch.equal(augmented["seq_a"], torch.zeros_like(augmented["seq_a"]))
+    assert torch.equal(augmented["seq_a_len"], torch.zeros_like(augmented["seq_a_len"]))
+    assert torch.equal(
+        augmented["seq_a_time_bucket"], torch.zeros_like(augmented["seq_a_time_bucket"])
+    )
+
+
+def test_feature_masking_compacts_sequence_lengths() -> None:
+    batch = _make_batch()
+    transform = PCVRFeatureMaskTransform(PCVRFeatureMaskConfig(probability=1.0))
+
+    augmented = transform(batch, generator=torch.Generator().manual_seed(5))
+
+    assert torch.equal(
+        augmented["user_int_feats"], torch.zeros_like(augmented["user_int_feats"])
+    )
+    assert torch.equal(
+        augmented["item_int_feats"], torch.zeros_like(augmented["item_int_feats"])
+    )
+    assert torch.equal(augmented["seq_a"], torch.zeros_like(augmented["seq_a"]))
+    assert torch.equal(augmented["seq_a_len"], torch.zeros_like(augmented["seq_a_len"]))
+    assert torch.equal(
+        augmented["seq_a_time_bucket"], torch.zeros_like(augmented["seq_a_time_bucket"])
+    )
+
+
+def test_augmentation_is_reproducible_with_fixed_generator_seed() -> None:
+    batch = _make_batch()
+    pipeline_config = PCVRDataPipelineConfig(
+        transforms=(
+            PCVRSequenceCropConfig(
+                views_per_row=2,
+                seq_window_mode="rolling",
+                seq_window_min_len=1,
+            ),
+            PCVRFeatureMaskConfig(probability=0.3),
+            PCVRDomainDropoutConfig(probability=0.2),
+        ),
+    )
+    pipeline = PCVRDataPipeline(transforms=build_pcvr_batch_transforms(pipeline_config))
+
+    first = pipeline.apply_transforms(
+        batch, generator=torch.Generator().manual_seed(99)
+    )
+    second = pipeline.apply_transforms(
+        batch, generator=torch.Generator().manual_seed(99)
+    )
+
+    _assert_tensor_dict_equal(first, second)
+
+
+def test_memory_batch_cache_returns_isolated_clones() -> None:
+    cache = PCVRMemoryBatchCache.from_config(
+        PCVRDataCacheConfig(mode="memory", max_batches=1)
+    )
+    cache.put(("file", 0, 0), _make_batch())
+
+    cached = cache.get(("file", 0, 0))
+    assert cached is not None
+    cached["user_int_feats"][0, 0] = 999
+
+    cached_again = cache.get(("file", 0, 0))
+    assert cached_again is not None
+    assert cached_again["user_int_feats"][0, 0].item() == 1
+
+
+def test_strict_time_filter_removes_future_sequence_events(tmp_path: Path) -> None:
+    schema_path = tmp_path / "schema.json"
+    parquet_path = tmp_path / "demo.parquet"
+    schema = {
+        "user_int": [[1, 10, 1]],
+        "item_int": [[2, 10, 1]],
+        "user_dense": [[3, 2]],
+        "seq": {
+            "seq_a": {
+                "prefix": "domain_a_seq",
+                "ts_fid": 10,
+                "features": [[10, 1000], [11, 100]],
+            }
+        },
+    }
+    schema_path.write_text(json.dumps(schema), encoding="utf-8")
+    table = pa.table(
+        {
+            "timestamp": [100],
+            "label_type": [2],
+            "user_id": ["u0"],
+            "user_int_feats_1": [1],
+            "item_int_feats_2": [2],
+            "user_dense_feats_3": [[0.1, 0.2]],
+            "domain_a_seq_10": [[10, 150, 90]],
+            "domain_a_seq_11": [[1, 2, 3]],
+        }
+    )
+    pq.write_table(table, parquet_path, row_group_size=1)
+    dataset = PCVRParquetDataset(
+        parquet_path=str(parquet_path),
+        schema_path=str(schema_path),
+        batch_size=1,
+        seq_max_lens={"seq_a": 3},
+        shuffle=False,
+        buffer_batches=0,
+        data_pipeline_config=PCVRDataPipelineConfig(
+            transforms=(PCVRSequenceCropConfig(),),
+            strict_time_filter=True,
+        ),
+    )
+
+    batch = next(iter(dataset))
+
+    assert batch["seq_a_len"].tolist() == [2]
+    assert batch["seq_a"].tolist() == [[[1, 3, 0]]]
+    assert batch["seq_a_time_bucket"][0, :2].gt(0).all()
+    assert batch["seq_a_time_bucket"][0, 2].item() == 0

--- a/tests/unit/test_pcvr_data_split.py
+++ b/tests/unit/test_pcvr_data_split.py
@@ -5,11 +5,23 @@ from pathlib import Path
 from torch.utils.data import IterableDataset
 
 import taac2026.infrastructure.pcvr.data as pcvr_data
+from taac2026.infrastructure.pcvr.config import (
+    PCVRDataCacheConfig,
+    PCVRDataPipelineConfig,
+    PCVRSequenceCropConfig,
+)
 
 
 class _FakeDataset(IterableDataset):
-    def __init__(self, *_args, row_group_range: tuple[int, int] | None = None, **_kwargs) -> None:
+    def __init__(
+        self,
+        *_args,
+        row_group_range: tuple[int, int] | None = None,
+        data_pipeline_config: PCVRDataPipelineConfig | None = None,
+        **_kwargs,
+    ) -> None:
         self.row_group_range = row_group_range
+        self.data_pipeline_config = data_pipeline_config
 
     def __iter__(self):
         return iter(())
@@ -43,7 +55,9 @@ def _patch_parquet_runtime(monkeypatch, row_group_rows: list[int]) -> None:
     )
 
 
-def test_get_pcvr_data_reuses_single_row_group_for_validation(monkeypatch, tmp_path: Path) -> None:
+def test_get_pcvr_data_reuses_single_row_group_for_validation(
+    monkeypatch, tmp_path: Path
+) -> None:
     _patch_parquet_runtime(monkeypatch, [1000])
     parquet_path = tmp_path / "demo.parquet"
     parquet_path.write_text("placeholder", encoding="utf-8")
@@ -60,8 +74,14 @@ def test_get_pcvr_data_reuses_single_row_group_for_validation(monkeypatch, tmp_p
     assert train_loader.dataset.row_group_range == (0, 1)
     assert valid_loader.dataset.row_group_range == (0, 1)
 
+    split_plan = pcvr_data.plan_pcvr_row_group_split([("demo.parquet", 0, 1000)])
+    assert split_plan.reuse_train_for_valid is True
+    assert split_plan.is_l1_ready is False
 
-def test_get_pcvr_data_keeps_disjoint_ranges_when_multiple_row_groups(monkeypatch, tmp_path: Path) -> None:
+
+def test_get_pcvr_data_keeps_disjoint_ranges_when_multiple_row_groups(
+    monkeypatch, tmp_path: Path
+) -> None:
     _patch_parquet_runtime(monkeypatch, [400, 300, 300])
     parquet_path = tmp_path / "demo.parquet"
     parquet_path.write_text("placeholder", encoding="utf-8")
@@ -78,3 +98,45 @@ def test_get_pcvr_data_keeps_disjoint_ranges_when_multiple_row_groups(monkeypatc
     assert train_dataset.row_group_range == (0, 2)
     assert train_loader.dataset.row_group_range == (0, 2)
     assert valid_loader.dataset.row_group_range == (2, 3)
+
+    split_plan = pcvr_data.plan_pcvr_row_group_split(
+        [
+            ("demo.parquet", 0, 400),
+            ("demo.parquet", 1, 300),
+            ("demo.parquet", 2, 300),
+        ],
+        valid_ratio=0.34,
+    )
+    assert split_plan.is_l1_ready is True
+    assert split_plan.train_rows == 700
+    assert split_plan.valid_rows == 300
+
+
+def test_get_pcvr_data_applies_augmentation_only_to_train_dataset(
+    monkeypatch, tmp_path: Path
+) -> None:
+    _patch_parquet_runtime(monkeypatch, [400, 300, 300])
+    parquet_path = tmp_path / "demo.parquet"
+    parquet_path.write_text("placeholder", encoding="utf-8")
+    data_pipeline_config = PCVRDataPipelineConfig(
+        cache=PCVRDataCacheConfig(mode="memory", max_batches=4),
+        transforms=(PCVRSequenceCropConfig(views_per_row=2),),
+        seed=11,
+    )
+
+    train_loader, valid_loader, train_dataset = pcvr_data.get_pcvr_data(
+        data_dir=str(parquet_path),
+        schema_path=str(tmp_path / "schema.json"),
+        batch_size=8,
+        valid_ratio=0.34,
+        num_workers=0,
+        buffer_batches=1,
+        data_pipeline_config=data_pipeline_config,
+    )
+
+    assert train_dataset.data_pipeline_config == data_pipeline_config
+    assert train_loader.dataset.data_pipeline_config == data_pipeline_config
+    assert valid_loader.dataset.data_pipeline_config is not None
+    assert valid_loader.dataset.data_pipeline_config.transforms == ()
+    assert train_loader.dataset.data_pipeline_config.cache == data_pipeline_config.cache
+    assert valid_loader.dataset.data_pipeline_config.cache == data_pipeline_config.cache

--- a/tests/unit/test_pcvr_infer_runtime.py
+++ b/tests/unit/test_pcvr_infer_runtime.py
@@ -6,26 +6,34 @@ from pathlib import Path
 
 import pytest
 
-from taac2026.domain.config import InferRequest
+from taac2026.domain.config import EvalRequest, InferRequest
+from taac2026.infrastructure.pcvr.config import PCVRDataConfig, PCVRTrainConfig
 from taac2026.infrastructure.pcvr.experiment import PCVRExperiment, _log_prediction_progress
 from taac2026.infrastructure.training.runtime import RuntimeExecutionConfig
 
 
-def _make_experiment(tmp_path: Path, *, default_train_args: tuple[str, ...] = ()) -> PCVRExperiment:
+def _make_experiment(tmp_path: Path, *, train_defaults: PCVRTrainConfig | None = None) -> PCVRExperiment:
     package_dir = tmp_path / "package"
     package_dir.mkdir()
     return PCVRExperiment(
         name="pcvr_symbiosis",
         package_dir=package_dir,
         model_class_name="DummyModel",
-        default_train_args=default_train_args,
+        train_defaults=train_defaults or PCVRTrainConfig(),
     )
 
 
-def test_resolve_infer_runtime_settings_falls_back_to_experiment_defaults(tmp_path: Path) -> None:
+def _write_train_config(checkpoint_dir: Path, overrides: dict[str, object] | None = None) -> None:
+    config = PCVRTrainConfig().to_flat_dict()
+    if overrides:
+        config.update(overrides)
+    (checkpoint_dir / "train_config.json").write_text(json.dumps(config), encoding="utf-8")
+
+
+def test_resolve_infer_runtime_settings_requires_train_config_values(tmp_path: Path) -> None:
     experiment = _make_experiment(
         tmp_path,
-        default_train_args=("--batch_size", "128", "--num_workers", "8"),
+        train_defaults=PCVRTrainConfig(data=PCVRDataConfig(batch_size=128, num_workers=8)),
     )
     request = InferRequest(
         experiment="config/symbiosis",
@@ -35,15 +43,14 @@ def test_resolve_infer_runtime_settings_falls_back_to_experiment_defaults(tmp_pa
         result_dir=tmp_path / "results",
     )
 
-    resolved = experiment._resolve_infer_runtime_settings(request, {})
-
-    assert resolved == (128, "experiment_default_train_args", 8, "experiment_default_train_args")
+    with pytest.raises(KeyError, match="batch_size"):
+        experiment._resolve_infer_runtime_settings(request, {})
 
 
 def test_resolve_infer_runtime_settings_preserves_explicit_request_values(tmp_path: Path) -> None:
     experiment = _make_experiment(
         tmp_path,
-        default_train_args=("--batch_size", "128", "--num_workers", "8"),
+        train_defaults=PCVRTrainConfig(data=PCVRDataConfig(batch_size=128, num_workers=8)),
     )
     request = InferRequest(
         experiment="config/symbiosis",
@@ -63,15 +70,12 @@ def test_resolve_infer_runtime_settings_preserves_explicit_request_values(tmp_pa
 def test_infer_uses_train_config_runtime_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     experiment = _make_experiment(
         tmp_path,
-        default_train_args=("--batch_size", "128", "--num_workers", "8"),
+        train_defaults=PCVRTrainConfig(data=PCVRDataConfig(batch_size=128, num_workers=8)),
     )
     checkpoint_dir = tmp_path / "checkpoint"
     checkpoint_dir.mkdir()
     (checkpoint_dir / "model.pt").write_bytes(b"checkpoint")
-    (checkpoint_dir / "train_config.json").write_text(
-        json.dumps({"batch_size": 96, "num_workers": 4}),
-        encoding="utf-8",
-    )
+    _write_train_config(checkpoint_dir, {"batch_size": 96, "num_workers": 4})
     captured: dict[str, object] = {}
 
     def fake_run_prediction_loop(**kwargs):
@@ -104,10 +108,10 @@ def test_infer_uses_train_config_runtime_settings(tmp_path: Path, monkeypatch: p
     }
 
 
-def test_resolve_prediction_runtime_execution_falls_back_to_experiment_defaults(tmp_path: Path) -> None:
+def test_resolve_prediction_runtime_execution_requires_train_config_values(tmp_path: Path) -> None:
     experiment = _make_experiment(
         tmp_path,
-        default_train_args=("--amp", "--amp-dtype", "float16", "--compile"),
+        train_defaults=PCVRTrainConfig(runtime=RuntimeExecutionConfig(amp=True, amp_dtype="float16", compile=True)),
     )
     request = InferRequest(
         experiment="config/symbiosis",
@@ -117,15 +121,27 @@ def test_resolve_prediction_runtime_execution_falls_back_to_experiment_defaults(
         result_dir=tmp_path / "results",
     )
 
-    runtime_execution, amp_source, amp_dtype_source, compile_source = experiment._resolve_prediction_runtime_execution(
-        request,
-        {},
-    )
+    with pytest.raises(KeyError, match="amp"):
+        experiment._resolve_prediction_runtime_execution(request, {})
 
-    assert runtime_execution == RuntimeExecutionConfig(amp=True, amp_dtype="float16", compile=True)
-    assert amp_source == "experiment_default_train_args"
-    assert amp_dtype_source == "experiment_default_train_args"
-    assert compile_source == "experiment_default_train_args"
+
+def test_load_train_config_requires_sidecar(tmp_path: Path) -> None:
+    experiment = _make_experiment(tmp_path)
+    checkpoint_dir = tmp_path / "checkpoint"
+    checkpoint_dir.mkdir()
+
+    with pytest.raises(FileNotFoundError, match=r"train_config\.json"):
+        experiment._load_train_config(checkpoint_dir)
+
+
+def test_load_train_config_requires_complete_sidecar(tmp_path: Path) -> None:
+    experiment = _make_experiment(tmp_path)
+    checkpoint_dir = tmp_path / "checkpoint"
+    checkpoint_dir.mkdir()
+    (checkpoint_dir / "train_config.json").write_text(json.dumps({"batch_size": 128}), encoding="utf-8")
+
+    with pytest.raises(KeyError, match="amp"):
+        experiment._load_train_config(checkpoint_dir)
 
 
 def test_infer_uses_train_config_runtime_execution(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -133,10 +149,7 @@ def test_infer_uses_train_config_runtime_execution(tmp_path: Path, monkeypatch: 
     checkpoint_dir = tmp_path / "checkpoint"
     checkpoint_dir.mkdir()
     (checkpoint_dir / "model.pt").write_bytes(b"checkpoint")
-    (checkpoint_dir / "train_config.json").write_text(
-        json.dumps({"amp": True, "amp_dtype": "float16", "compile": True}),
-        encoding="utf-8",
-    )
+    _write_train_config(checkpoint_dir, {"amp": True, "amp_dtype": "float16", "compile": True})
     captured: dict[str, object] = {}
 
     def fake_bound_run_prediction_loop(self, **kwargs):
@@ -159,6 +172,54 @@ def test_infer_uses_train_config_runtime_execution(tmp_path: Path, monkeypatch: 
 
     runtime_execution = captured["runtime_execution"]
     assert runtime_execution == RuntimeExecutionConfig(amp=True, amp_dtype="float16", compile=True)
+
+
+def test_evaluate_writes_score_diagnostics(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    experiment = _make_experiment(tmp_path)
+    checkpoint_dir = tmp_path / "checkpoint"
+    checkpoint_dir.mkdir()
+    checkpoint_path = checkpoint_dir / "model.pt"
+    checkpoint_path.write_bytes(b"checkpoint")
+    _write_train_config(checkpoint_dir)
+
+    def fake_bound_run_prediction_loop(self, **kwargs):
+        del self, kwargs
+        return {
+            "labels": [0.0, 1.0, 1.0, 0.0],
+            "probabilities": [0.1, 0.9, 0.8, 0.2],
+            "records": [
+                {"user_id": "u0", "score": 0.1, "target": 0.0, "timestamp": None},
+                {"user_id": "u1", "score": 0.9, "target": 1.0, "timestamp": None},
+            ],
+        }
+
+    monkeypatch.setattr(PCVRExperiment, "_run_prediction_loop", fake_bound_run_prediction_loop)
+    monkeypatch.setattr(
+        "taac2026.infrastructure.pcvr.experiment.pcvr_data.collect_pcvr_row_groups",
+        lambda _path: [(str(tmp_path / "eval.parquet"), 0, 2), (str(tmp_path / "eval.parquet"), 1, 2)],
+    )
+    output_path = tmp_path / "evaluation.json"
+    request = EvalRequest(
+        experiment="config/symbiosis",
+        dataset_path=tmp_path / "eval.parquet",
+        schema_path=None,
+        run_dir=checkpoint_dir,
+        checkpoint_path=checkpoint_path,
+        output_path=output_path,
+        predictions_path=tmp_path / "predictions.jsonl",
+    )
+
+    payload = experiment.evaluate(request)
+
+    diagnostics = payload["metrics"]["score_diagnostics"]
+    assert diagnostics["positive_count"] == 2
+    assert diagnostics["negative_count"] == 2
+    assert diagnostics["score_margin_mean"] == pytest.approx(0.7)
+    assert payload["metrics"]["auc_ci"]["low"] <= payload["metrics"]["auc"] <= payload["metrics"]["auc_ci"]["high"]
+    assert payload["data_diagnostics"]["row_group_split"]["is_l1_ready"] is True
+    saved_payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert saved_payload["metrics"]["score_diagnostics"] == diagnostics
+    assert saved_payload["data_diagnostics"] == payload["data_diagnostics"]
 
 
 def test_infer_request_runtime_settings_override_train_config(tmp_path: Path) -> None:

--- a/tests/unit/test_pcvr_protocol.py
+++ b/tests/unit/test_pcvr_protocol.py
@@ -76,6 +76,20 @@ def test_load_ns_groups_rejects_missing_explicit_file(tmp_path) -> None:
         load_ns_groups(dataset, {"ns_groups_json": "missing.json"}, tmp_path, tmp_path)
 
 
+def test_load_ns_groups_requires_explicit_config_key(tmp_path) -> None:
+    dataset = type(
+        "Dataset",
+        (),
+        {
+            "user_int_schema": type("Schema", (), {"entries": [(10, 0, 1)]})(),
+            "item_int_schema": type("Schema", (), {"entries": [(7, 0, 1)]})(),
+        },
+    )()
+
+    with pytest.raises(KeyError, match="ns_groups_json"):
+        load_ns_groups(dataset, {}, tmp_path, tmp_path)
+
+
 def test_batch_to_model_input_uses_zero_time_buckets_when_missing() -> None:
     batch = {
         "user_int_feats": torch.ones(2, 1, dtype=torch.long),

--- a/tests/unit/test_pcvr_trainer.py
+++ b/tests/unit/test_pcvr_trainer.py
@@ -4,11 +4,16 @@ from contextlib import contextmanager
 import logging
 import math
 
+import pytest
 import torch
 
 import taac2026.infrastructure.pcvr.trainer as trainer_module
 from taac2026.infrastructure.pcvr.trainer import PCVRPointwiseTrainer
-from taac2026.infrastructure.training.runtime import EarlyStopping, RuntimeExecutionConfig
+from taac2026.infrastructure.training.runtime import (
+    BinaryClassificationLossConfig,
+    EarlyStopping,
+    RuntimeExecutionConfig,
+)
 
 
 class _DummyModel(torch.nn.Module):
@@ -101,6 +106,47 @@ def test_trainer_runtime_execution_wraps_train_and_predict(monkeypatch, tmp_path
     assert autocast_devices == ["cpu", "cpu"]
 
 
+def test_trainer_delegates_loss_to_shared_runtime(monkeypatch, tmp_path) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_compute_binary_classification_loss(logits, targets, loss_config, reduction="mean"):
+        captured["logits_shape"] = tuple(logits.shape)
+        captured["targets"] = targets.detach().clone()
+        captured["loss_config"] = loss_config
+        captured["reduction"] = reduction
+        return logits.mean() * 0 + 0.25
+
+    monkeypatch.setattr(trainer_module, "compute_binary_classification_loss", fake_compute_binary_classification_loss)
+
+    trainer = PCVRPointwiseTrainer(
+        model=_DummyModel(),
+        model_input_type=object,
+        train_loader=[],
+        valid_loader=[],
+        lr=1e-3,
+        num_epochs=1,
+        device="cpu",
+        save_dir=tmp_path / "checkpoints",
+        early_stopping=EarlyStopping(tmp_path / "best" / "model.pt", patience=2),
+        loss_type="FOCAL",
+        focal_alpha=0.25,
+        focal_gamma=1.5,
+    )
+    monkeypatch.setattr(trainer, "_make_model_input", lambda batch: object())
+
+    train_loss = trainer._train_step({"label": torch.tensor([1.0])})
+
+    assert train_loss == pytest.approx(0.25)
+    assert captured["logits_shape"] == (1,)
+    assert torch.equal(captured["targets"], torch.tensor([1.0]))
+    assert captured["reduction"] == "mean"
+    assert captured["loss_config"] == BinaryClassificationLossConfig(
+        loss_type="focal",
+        focal_alpha=0.25,
+        focal_gamma=1.5,
+    )
+
+
 def test_evaluate_accepts_bfloat16_logits(tmp_path) -> None:
     trainer = PCVRPointwiseTrainer(
         model=_DummyModel(),
@@ -125,3 +171,37 @@ def test_evaluate_accepts_bfloat16_logits(tmp_path) -> None:
 
     assert auc == 1.0
     assert math.isfinite(logloss)
+
+
+def test_evaluate_records_score_diagnostics(tmp_path, caplog) -> None:
+    trainer = PCVRPointwiseTrainer(
+        model=_DummyModel(),
+        model_input_type=object,
+        train_loader=[],
+        valid_loader=[
+            {"label": torch.tensor([0.0, 1.0])},
+            {"label": torch.tensor([1.0, 0.0])},
+        ],
+        lr=1e-3,
+        num_epochs=1,
+        device="cpu",
+        save_dir=tmp_path / "checkpoints",
+        early_stopping=EarlyStopping(tmp_path / "best" / "model.pt", patience=2),
+    )
+    logits = iter(
+        (
+            torch.tensor([-2.0, 2.0]),
+            torch.tensor([1.0, -1.0]),
+        )
+    )
+    trainer._evaluate_step = lambda batch: (next(logits), batch["label"])
+
+    with caplog.at_level(logging.INFO):
+        auc, logloss = trainer.evaluate(epoch=1)
+
+    assert auc == 1.0
+    assert math.isfinite(logloss)
+    assert trainer.last_eval_diagnostics["positive_count"] == 2
+    assert trainer.last_eval_diagnostics["negative_count"] == 2
+    assert trainer.last_eval_diagnostics["positive_score_mean"] > trainer.last_eval_diagnostics["negative_score_mean"]
+    assert "Validation score diagnostics" in caplog.text

--- a/tests/unit/test_runtime_contract_matrix.py
+++ b/tests/unit/test_runtime_contract_matrix.py
@@ -330,7 +330,6 @@ def test_load_ns_groups_raises_for_unknown_feature_ids(
 @pytest.mark.parametrize(
     ("config", "bucket_count", "expected"),
     [
-        ({}, 65, 65),
         ({"use_time_buckets": True}, 7, 7),
         ({"use_time_buckets": False}, 9, 0),
         ({"use_time_buckets": 0}, 11, 0),
@@ -340,6 +339,11 @@ def test_num_time_buckets_cases(config: dict[str, object], bucket_count: int, ex
     data_module = SimpleNamespace(NUM_TIME_BUCKETS=bucket_count)
 
     assert num_time_buckets(config, data_module) == expected
+
+
+def test_num_time_buckets_requires_explicit_config() -> None:
+    with pytest.raises(KeyError, match="use_time_buckets"):
+        num_time_buckets({}, SimpleNamespace(NUM_TIME_BUCKETS=65))
 
 
 @pytest.mark.parametrize(
@@ -649,14 +653,15 @@ def test_load_experiment_package_accepts_path_and_module_identifiers(
 
 
 def test_experiment_package_contracts(loaded_experiment, experiment_case: ExperimentCase) -> None:
+    train_defaults = loaded_experiment.train_defaults.to_flat_dict()
+
     assert loaded_experiment.name == experiment_case.name
     assert loaded_experiment.package_dir == (REPO_ROOT / experiment_case.path).resolve()
-    assert loaded_experiment.default_train_args
+    assert loaded_experiment.train_defaults is not None
     assert loaded_experiment.metadata["kind"] == "pcvr"
     assert loaded_experiment.metadata["model_class"] == experiment_case.model_class
-    assert "--ns_groups_json" in loaded_experiment.default_train_args
-    assert "ns_groups.json" in loaded_experiment.default_train_args
-    assert "--num_hyformer_blocks" not in loaded_experiment.default_train_args
+    assert train_defaults["ns_groups_json"] == "ns_groups.json"
+    assert "num_hyformer_blocks" not in train_defaults
 
 
 def test_model_module_contracts(loaded_model_module, experiment_case: ExperimentCase) -> None:

--- a/tests/unit/test_training_cli.py
+++ b/tests/unit/test_training_cli.py
@@ -2,6 +2,16 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
+from taac2026.infrastructure.pcvr.config import (
+    PCVRDataCacheConfig,
+    PCVRDataPipelineConfig,
+    PCVRDomainDropoutConfig,
+    PCVRFeatureMaskConfig,
+    PCVRSequenceCropConfig,
+    PCVRTrainConfig,
+)
 from taac2026.infrastructure.pcvr.training import parse_pcvr_train_args
 from taac2026.application.training.cli import parse_train_args
 
@@ -35,3 +45,94 @@ def test_parse_pcvr_train_args_accepts_runtime_flags(tmp_path: Path) -> None:
     assert args.amp is True
     assert args.amp_dtype == "float16"
     assert args.compile is True
+
+
+def test_parse_pcvr_train_args_accepts_symbiosis_ablation_flags(tmp_path: Path) -> None:
+    args = parse_pcvr_train_args(
+        [
+            "--no-symbiosis-use-user-item-graph",
+            "--no-symbiosis-use-fourier-time",
+            "--no-symbiosis-use-context-exchange",
+            "--no-symbiosis-use-multi-scale",
+            "--symbiosis-use-domain-gate",
+        ],
+        package_dir=tmp_path,
+    )
+
+    assert args.symbiosis_use_user_item_graph is False
+    assert args.symbiosis_use_fourier_time is False
+    assert args.symbiosis_use_context_exchange is False
+    assert args.symbiosis_use_multi_scale is False
+    assert args.symbiosis_use_domain_gate is True
+
+
+def test_parse_pcvr_train_args_rejects_data_pipeline_flags(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit):
+        parse_pcvr_train_args(
+            ["--data-pipeline-transforms", "sequence_crop,feature_mask"],
+            package_dir=tmp_path,
+        )
+
+
+def test_parse_pcvr_train_args_uses_typed_data_pipeline_defaults(
+    tmp_path: Path,
+) -> None:
+    defaults = PCVRTrainConfig(
+        data_pipeline=PCVRDataPipelineConfig(
+            cache=PCVRDataCacheConfig(mode="memory", max_batches=32),
+            seed=77,
+            transforms=(
+                PCVRSequenceCropConfig(
+                    views_per_row=2,
+                    seq_window_mode="random_tail",
+                    seq_window_min_len=8,
+                ),
+                PCVRFeatureMaskConfig(probability=0.05),
+            ),
+        )
+    )
+
+    args = parse_pcvr_train_args([], package_dir=tmp_path, defaults=defaults)
+
+    assert not hasattr(args, "data_pipeline_transforms")
+    assert not hasattr(args, "augmentation_mode")
+
+
+def test_pcvr_train_config_serializes_structured_data_pipeline() -> None:
+    defaults = PCVRTrainConfig(
+        data_pipeline=PCVRDataPipelineConfig(
+            cache=PCVRDataCacheConfig(mode="memory", max_batches=32),
+            seed=77,
+            strict_time_filter=False,
+            transforms=(
+                PCVRSequenceCropConfig(
+                    views_per_row=2,
+                    seq_window_mode="random_tail",
+                    seq_window_min_len=8,
+                ),
+                PCVRFeatureMaskConfig(probability=0.05),
+                PCVRDomainDropoutConfig(probability=0.1),
+            ),
+        )
+    )
+
+    flat_config = defaults.to_flat_dict()
+
+    assert "data_pipeline_transforms" not in flat_config
+    assert "augmentation_mode" not in flat_config
+    assert flat_config["data_pipeline"] == {
+        "cache": {"mode": "memory", "max_batches": 32},
+        "seed": 77,
+        "strict_time_filter": False,
+        "transforms": [
+            {
+                "name": "sequence_crop",
+                "enabled": True,
+                "views_per_row": 2,
+                "seq_window_mode": "random_tail",
+                "seq_window_min_len": 8,
+            },
+            {"name": "feature_mask", "enabled": True, "probability": 0.05},
+            {"name": "domain_dropout", "enabled": True, "probability": 0.1},
+        ],
+    }

--- a/tools/benchmark_pcvr_data_pipeline.py
+++ b/tools/benchmark_pcvr_data_pipeline.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Benchmark PCVR data pipeline throughput without running a model."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import torch
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = REPO_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from taac2026.infrastructure.pcvr.config import (  # noqa: E402
+    PCVRDataCacheConfig,
+    PCVRDataPipelineConfig,
+    PCVRDomainDropoutConfig,
+    PCVRFeatureMaskConfig,
+    PCVRSequenceCropConfig,
+)
+from taac2026.infrastructure.pcvr.data import get_pcvr_data  # noqa: E402
+from taac2026.infrastructure.pcvr.protocol import parse_seq_max_lens  # noqa: E402
+
+
+def _build_pipeline_config(args: argparse.Namespace) -> PCVRDataPipelineConfig:
+    transforms = []
+    cache = PCVRDataCacheConfig()
+    if args.pipeline_preset in {"cache", "augment"}:
+        cache = PCVRDataCacheConfig(mode="memory", max_batches=args.cache_batches)
+    if args.pipeline_preset == "augment":
+        transforms.extend(
+            [
+                PCVRSequenceCropConfig(
+                    views_per_row=args.views_per_row,
+                    seq_window_mode="random_tail",
+                    seq_window_min_len=args.seq_window_min_len,
+                ),
+                PCVRFeatureMaskConfig(probability=args.feature_mask_probability),
+                PCVRDomainDropoutConfig(probability=args.domain_dropout_probability),
+            ]
+        )
+    return PCVRDataPipelineConfig(
+        cache=cache,
+        transforms=tuple(transforms),
+        seed=args.seed,
+        strict_time_filter=args.strict_time_filter,
+    )
+
+
+def _consume_batches(iterator: Any, batch_count: int) -> int:
+    rows = 0
+    for _ in range(batch_count):
+        batch = next(iterator)
+        rows += int(batch["label"].shape[0])
+    return rows
+
+
+def run_benchmark(args: argparse.Namespace) -> dict[str, object]:
+    if args.torch_threads > 0:
+        torch.set_num_threads(args.torch_threads)
+
+    pipeline_config = _build_pipeline_config(args)
+    train_loader, _valid_loader, train_dataset = get_pcvr_data(
+        data_dir=str(args.dataset_path),
+        schema_path=str(args.schema_path),
+        batch_size=args.batch_size,
+        valid_ratio=args.valid_ratio,
+        train_ratio=args.train_ratio,
+        num_workers=args.num_workers,
+        buffer_batches=args.buffer_batches,
+        shuffle_train=not args.no_shuffle,
+        seed=args.seed,
+        seq_max_lens=parse_seq_max_lens(args.seq_max_lens),
+        data_pipeline_config=pipeline_config,
+    )
+
+    iterator = iter(train_loader)
+    warmup_rows = 0
+    try:
+        warmup_rows = _consume_batches(iterator, args.warmup_batches)
+    except StopIteration:
+        return {
+            "dataset_path": str(args.dataset_path),
+            "schema_path": str(args.schema_path),
+            "pipeline_preset": args.pipeline_preset,
+            "train_rows": train_dataset.num_rows,
+            "measured_rows": 0,
+            "measured_batches": 0,
+            "warmup_rows": warmup_rows,
+            "elapsed_sec": 0.0,
+            "rows_per_sec": 0.0,
+            "batches_per_sec": 0.0,
+        }
+
+    measured_rows = 0
+    measured_batches = 0
+    started = time.perf_counter()
+    while args.max_batches <= 0 or measured_batches < args.max_batches:
+        try:
+            batch = next(iterator)
+        except StopIteration:
+            break
+        measured_rows += int(batch["label"].shape[0])
+        measured_batches += 1
+    elapsed = time.perf_counter() - started
+
+    return {
+        "dataset_path": str(args.dataset_path),
+        "schema_path": str(args.schema_path),
+        "pipeline_preset": args.pipeline_preset,
+        "train_rows": train_dataset.num_rows,
+        "train_row_groups": len(train_dataset._rg_list),
+        "batch_size": args.batch_size,
+        "num_workers": args.num_workers,
+        "buffer_batches": args.buffer_batches,
+        "shuffle": not args.no_shuffle,
+        "warmup_batches": args.warmup_batches,
+        "warmup_rows": warmup_rows,
+        "measured_rows": measured_rows,
+        "measured_batches": measured_batches,
+        "elapsed_sec": elapsed,
+        "rows_per_sec": measured_rows / elapsed if elapsed > 0 else 0.0,
+        "batches_per_sec": measured_batches / elapsed if elapsed > 0 else 0.0,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset-path", type=Path, required=True)
+    parser.add_argument("--schema-path", type=Path, required=True)
+    parser.add_argument("--batch-size", type=int, default=256)
+    parser.add_argument("--num-workers", type=int, default=0)
+    parser.add_argument("--buffer-batches", type=int, default=1)
+    parser.add_argument("--valid-ratio", type=float, default=0.1)
+    parser.add_argument("--train-ratio", type=float, default=1.0)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--seq-max-lens", default="seq_a:256,seq_b:256,seq_c:512,seq_d:512"
+    )
+    parser.add_argument("--max-batches", type=int, default=0)
+    parser.add_argument("--warmup-batches", type=int, default=5)
+    parser.add_argument("--torch-threads", type=int, default=0)
+    parser.add_argument("--no-shuffle", action="store_true")
+    parser.add_argument(
+        "--pipeline-preset",
+        choices=("none", "cache", "augment"),
+        default="none",
+    )
+    parser.add_argument("--cache-batches", type=int, default=512)
+    parser.add_argument("--views-per-row", type=int, default=2)
+    parser.add_argument("--seq-window-min-len", type=int, default=8)
+    parser.add_argument("--feature-mask-probability", type=float, default=0.05)
+    parser.add_argument("--domain-dropout-probability", type=float, default=0.05)
+    parser.add_argument(
+        "--strict-time-filter", action=argparse.BooleanOptionalAction, default=True
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    summary = run_benchmark(parse_args())
+    print(json.dumps(summary, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/generate_pcvr_synthetic_dataset.py
+++ b/tools/generate_pcvr_synthetic_dataset.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Generate an amplified synthetic PCVR parquet dataset for loader benchmarks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.parquet as pq
+
+
+def _replace_column(table: pa.Table, name: str, values: pa.ChunkedArray) -> pa.Table:
+    index = table.schema.get_field_index(name)
+    if index < 0:
+        return table
+    field = table.schema.field(index)
+    return table.set_column(index, field, values.cast(field.type))
+
+
+def _offset_scalar_column(table: pa.Table, name: str, offset: int) -> pa.Table:
+    index = table.schema.get_field_index(name)
+    if index < 0 or offset == 0:
+        return table
+    field = table.schema.field(index)
+    if not pa.types.is_integer(field.type):
+        return table
+    values = pc.add(table.column(name), pa.scalar(offset, type=field.type))
+    return _replace_column(table, name, values)
+
+
+def _make_repeat_chunk(
+    table: pa.Table, repeat_index: int, *, jitter_ids: bool
+) -> pa.Table:
+    if not jitter_ids or repeat_index == 0:
+        return table
+
+    rows = table.num_rows
+    id_offset = repeat_index * rows
+    time_offset = repeat_index * 86_400
+    chunk = table
+    chunk = _offset_scalar_column(chunk, "user_id", id_offset)
+    chunk = _offset_scalar_column(chunk, "item_id", id_offset)
+    chunk = _offset_scalar_column(chunk, "timestamp", time_offset)
+    chunk = _offset_scalar_column(chunk, "label_time", time_offset)
+    return chunk
+
+
+def generate_dataset(
+    *,
+    source_dir: Path,
+    output_dir: Path,
+    multiplier: int,
+    row_group_size: int | None,
+    compression: str,
+    jitter_ids: bool,
+    force: bool,
+) -> dict[str, object]:
+    source_parquet = source_dir / "demo_1000.parquet"
+    source_schema = source_dir / "schema.json"
+    if not source_parquet.exists():
+        raise FileNotFoundError(f"source parquet not found: {source_parquet}")
+    if not source_schema.exists():
+        raise FileNotFoundError(f"source schema not found: {source_schema}")
+
+    if output_dir.exists():
+        if not force:
+            raise FileExistsError(f"output directory already exists: {output_dir}")
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    table = pq.read_table(source_parquet)
+    output_parquet = output_dir / f"demo_{table.num_rows * multiplier}.parquet"
+    resolved_row_group_size = row_group_size or table.num_rows
+
+    with pq.ParquetWriter(
+        output_parquet, table.schema, compression=compression
+    ) as writer:
+        for repeat_index in range(multiplier):
+            chunk = _make_repeat_chunk(table, repeat_index, jitter_ids=jitter_ids)
+            writer.write_table(chunk, row_group_size=resolved_row_group_size)
+
+    shutil.copy2(source_schema, output_dir / "schema.json")
+    parquet_file = pq.ParquetFile(output_parquet)
+    return {
+        "output_dir": str(output_dir),
+        "parquet_path": str(output_parquet),
+        "schema_path": str(output_dir / "schema.json"),
+        "rows": parquet_file.metadata.num_rows,
+        "row_groups": parquet_file.metadata.num_row_groups,
+        "source_rows": table.num_rows,
+        "multiplier": multiplier,
+        "row_group_size": resolved_row_group_size,
+        "compression": compression,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--source-dir",
+        type=Path,
+        default=Path("data/sample_1000_raw"),
+        help="Directory containing demo_1000.parquet and schema.json.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("outputs/perf/pcvr_synthetic_100x"),
+        help="Directory to create for the amplified dataset.",
+    )
+    parser.add_argument("--multiplier", type=int, default=100)
+    parser.add_argument("--row-group-size", type=int, default=0)
+    parser.add_argument("--compression", default="snappy")
+    parser.add_argument("--no-jitter-ids", action="store_true")
+    parser.add_argument("--force", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    summary = generate_dataset(
+        source_dir=args.source_dir,
+        output_dir=args.output_dir,
+        multiplier=args.multiplier,
+        row_group_size=args.row_group_size or None,
+        compression=args.compression,
+        jitter_ids=not args.no_jitter_ids,
+        force=args.force,
+    )
+    print(json.dumps(summary, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/zensical.toml
+++ b/zensical.toml
@@ -42,6 +42,7 @@ nav = [
         { "官方平台用户指南" = "guide/official-competition-docs.md" },
         { "线上训练打包" = "guide/online-training-bundle.md" },
         { "比赛线上服务器设备信息" = "guide/competition-online-server.md" },
+        { "PCVR 数据管道" = "guide/pcvr-data-pipeline.md" },
         { "超参数搜索" = "guide/search.md" },
         { "测试" = "guide/testing.md" },
         { "Triton Kernel 开发" = "guide/triton-kernels.md" },
@@ -55,6 +56,7 @@ nav = [
         { "特征Token化·长序列注意力·辅助Loss" = "ideas/posts/001-rec-model-work-summary.md" },
         { "腾讯广告算法大赛 2025 官方论文解读：全模态生成式推荐" = "ideas/posts/002-taac2025-competition-paper.md" },
         { "Learning Mechanics 分析方法：从缩放律、学习量子到低秩动力学" = "ideas/posts/003-learning-mechanics-analysis.md" },
+        { "Symbiosis V2 改造与实验验证计划" = "ideas/posts/004-symbiosis-v2-experiment-plan.md" },
     ] },
     { "论文" = [
         { "技术发展时间线" = "papers/index.md" },


### PR DESCRIPTION
## Summary

Closes #24.

This PR implements the PCVR training-time data pipeline as a composable shared-runtime feature:

- adds typed PCVR train/data-pipeline config objects for experiment-side composition
- adds training-only PCVR batch pipeline components: memory cache, sequence crop, feature mask, domain dropout, and row-level shuffle buffering
- wires the pipeline through `get_pcvr_data` so train can use transforms while valid/eval/infer remain deterministic and unaugmented
- keeps data-pipeline configuration out of the training CLI, so experiments configure it through `PCVRTrainConfig.data_pipeline`
- adds strict timestamp filtering for augmented training views
- adds a 100x synthetic dataset generator and loader-only benchmark utility
- expands unit coverage and documentation for pipeline components and extension ideas

## Validation

- `uv run --with ruff ruff check src/taac2026 tests/unit tools`
- `uv run pytest tests/unit -q` (`286 passed`)

## Local throughput smoke

Generated a local ignored benchmark dataset with:

```bash
uv run python tools/generate_pcvr_synthetic_dataset.py --force
```

The generated parquet has 100000 rows and 100 Row Groups under `outputs/perf/pcvr_synthetic_100x/` and is not committed.

Observed loader-only benchmark results on this dev container, `batch_size=256`:

- base loader, `num_workers=0`: about 4.16k rows/s
- base loader, `num_workers=2`: about 7.13k rows/s
- augmented pipeline, `num_workers=0`: about 2.36k expanded rows/s
- augmented pipeline, `num_workers=2`: about 3.51k expanded rows/s

## Notes

Issue #24 originally listed CLI flags as one possible control surface. The final implementation intentionally uses typed experiment config only, matching the current package-level configuration direction and avoiding data-pipeline-specific CLI overrides.