### PR TITLE
Print resolved schema.json in eval output

### DIFF
--- a/src/taac2026/application/evaluation/cli.py
+++ b/src/taac2026/application/evaluation/cli.py
@@ -94,7 +94,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         payload = experiment.infer(request)
 
     if args.json:
-        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        print(json.dumps(payload, ensure_ascii=False, separators=(",", ":")))
     else:
         print(json.dumps(payload, ensure_ascii=False))
     return 0

--- a/src/taac2026/infrastructure/pcvr/experiment.py
+++ b/src/taac2026/infrastructure/pcvr/experiment.py
@@ -19,7 +19,7 @@ from torch.utils.data import DataLoader
 
 from taac2026.domain.config import EvalRequest, InferRequest, TrainRequest
 from taac2026.domain.metrics import compute_classification_metrics
-from taac2026.infrastructure.checkpoints import resolve_checkpoint_path
+from taac2026.infrastructure.checkpoints import load_checkpoint_state_dict, resolve_checkpoint_path
 from taac2026.infrastructure.io.files import read_json, write_json
 import taac2026.infrastructure.pcvr.data as pcvr_data
 from taac2026.infrastructure.pcvr.config import PCVRTrainConfig, REQUIRED_PCVR_TRAIN_CONFIG_KEYS
@@ -155,6 +155,12 @@ class PCVRExperiment:
         output_path = request.output_path or (request.run_dir / "evaluation.json")
         predictions_path = request.predictions_path or (request.run_dir / "validation_predictions.jsonl")
         config = self._load_train_config(checkpoint.parent)
+        resolved_schema_path, resolved_schema = self._load_resolved_schema(
+            dataset_path=request.dataset_path,
+            schema_path=request.schema_path,
+            checkpoint_dir=checkpoint.parent,
+            mode="evaluation",
+        )
         effective_batch_size, batch_size_source, effective_num_workers, num_workers_source = self._resolve_prediction_runtime_settings(
             request,
             config,
@@ -182,7 +188,7 @@ class PCVRExperiment:
         with self._module_context():
             evaluation = self._run_prediction_loop(
                 dataset_path=request.dataset_path,
-                schema_path=request.schema_path,
+                schema_path=resolved_schema_path,
                 checkpoint_path=checkpoint,
                 batch_size=effective_batch_size,
                 num_workers=effective_num_workers,
@@ -208,6 +214,8 @@ class PCVRExperiment:
         payload = {
             "experiment_name": self.name,
             "checkpoint_path": str(checkpoint),
+            "schema_path": str(resolved_schema_path),
+            "schema": resolved_schema,
             "metrics": metrics,
             "data_diagnostics": self._build_evaluation_data_diagnostics(request.dataset_path),
             "validation_predictions_path": str(predictions_path),
@@ -260,6 +268,12 @@ class PCVRExperiment:
         if checkpoint is None:
             checkpoint = resolve_checkpoint_path(Path.cwd())
         config = self._load_train_config(checkpoint.parent)
+        resolved_schema_path, resolved_schema = self._load_resolved_schema(
+            dataset_path=request.dataset_path,
+            schema_path=request.schema_path,
+            checkpoint_dir=checkpoint.parent,
+            mode="inference",
+        )
         effective_batch_size, batch_size_source, effective_num_workers, num_workers_source = self._resolve_prediction_runtime_settings(
             request,
             config,
@@ -287,7 +301,7 @@ class PCVRExperiment:
         with self._module_context():
             evaluation = self._run_prediction_loop(
                 dataset_path=request.dataset_path,
-                schema_path=request.schema_path,
+                schema_path=resolved_schema_path,
                 checkpoint_path=checkpoint,
                 batch_size=effective_batch_size,
                 num_workers=effective_num_workers,
@@ -306,6 +320,8 @@ class PCVRExperiment:
         write_json(output_path, {"predictions": prediction_map})
         return {
             "checkpoint_path": str(checkpoint),
+            "schema_path": str(resolved_schema_path),
+            "schema": resolved_schema,
             "predictions_path": str(output_path),
             "prediction_count": len(prediction_map),
             "batch_size": effective_batch_size,
@@ -454,7 +470,7 @@ class PCVRExperiment:
         runtime_device = torch.device(device)
         resolved_runtime_execution = runtime_execution or RuntimeExecutionConfig()
         model.to(runtime_device)
-        state_dict = torch.load(checkpoint_path, map_location=runtime_device)
+        state_dict = load_checkpoint_state_dict(checkpoint_path, map_location=runtime_device)
         model.load_state_dict(state_dict)
         model.eval()
         predict_fn = maybe_compile_callable(
@@ -544,6 +560,18 @@ class PCVRExperiment:
             joined = ", ".join(missing_keys)
             raise KeyError(f"PCVR train_config.json is missing required key(s): {joined}")
         return config
+
+    def _load_resolved_schema(
+        self,
+        *,
+        dataset_path: Path,
+        schema_path: Path | None,
+        checkpoint_dir: Path,
+        mode: str,
+    ) -> tuple[Path, Any]:
+        resolved_schema_path = self._resolve_schema_path(dataset_path, schema_path, checkpoint_dir)
+        logging.info("Resolved PCVR %s schema.json: %s", mode, resolved_schema_path)
+        return resolved_schema_path, read_json(resolved_schema_path)
 
     def _resolve_schema_path(self, dataset_path: Path, schema_path: Path | None, checkpoint_dir: Path) -> Path:
         return resolve_schema_path(dataset_path, schema_path, checkpoint_dir)

--- a/src/taac2026/infrastructure/pcvr/experiment.py
+++ b/src/taac2026/infrastructure/pcvr/experiment.py
@@ -19,7 +19,7 @@ from torch.utils.data import DataLoader
 
 from taac2026.domain.config import EvalRequest, InferRequest, TrainRequest
 from taac2026.domain.metrics import compute_classification_metrics
-from taac2026.infrastructure.checkpoints import load_checkpoint_state_dict, resolve_checkpoint_path
+from taac2026.infrastructure.checkpoints import resolve_checkpoint_path
 from taac2026.infrastructure.io.files import read_json, write_json
 import taac2026.infrastructure.pcvr.data as pcvr_data
 from taac2026.infrastructure.pcvr.config import PCVRTrainConfig, REQUIRED_PCVR_TRAIN_CONFIG_KEYS
@@ -470,7 +470,7 @@ class PCVRExperiment:
         runtime_device = torch.device(device)
         resolved_runtime_execution = runtime_execution or RuntimeExecutionConfig()
         model.to(runtime_device)
-        state_dict = load_checkpoint_state_dict(checkpoint_path, map_location=runtime_device)
+        state_dict = torch.load(checkpoint_path, map_location=runtime_device)
         model.load_state_dict(state_dict)
         model.eval()
         predict_fn = maybe_compile_callable(

--- a/tests/unit/test_evaluation_cli.py
+++ b/tests/unit/test_evaluation_cli.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+
+import taac2026.application.evaluation.cli as evaluation_cli
 from taac2026.application.evaluation.cli import parse_eval_args
 
 
@@ -22,3 +25,35 @@ def test_parse_eval_args_accepts_runtime_flags() -> None:
     assert args.amp is True
     assert args.amp_dtype == "bfloat16"
     assert args.compile is True
+
+
+def test_main_json_output_is_compact_single_line(monkeypatch, capsys) -> None:
+    payload = {
+        "checkpoint_path": "/tmp/model.pt",
+        "schema_path": "/tmp/schema.json",
+        "schema": {"features": [{"name": "user_id"}]},
+    }
+
+    class FakeExperiment:
+        def infer(self, request):
+            del request
+            return payload
+
+    monkeypatch.setattr(evaluation_cli, "load_experiment_package", lambda _experiment: FakeExperiment())
+
+    exit_code = evaluation_cli.main(
+        [
+            "infer",
+            "--dataset-path",
+            "/tmp/eval.parquet",
+            "--result-dir",
+            "/tmp/results",
+            "--json",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "\n" not in captured.out.strip()
+    assert '"schema":{"features":[{"name":"user_id"}]}' in captured.out.strip()
+    assert json.loads(captured.out) == payload

--- a/tests/unit/test_pcvr_infer_runtime.py
+++ b/tests/unit/test_pcvr_infer_runtime.py
@@ -75,6 +75,8 @@ def test_infer_uses_train_config_runtime_settings(tmp_path: Path, monkeypatch: p
     checkpoint_dir = tmp_path / "checkpoint"
     checkpoint_dir.mkdir()
     (checkpoint_dir / "model.pt").write_bytes(b"checkpoint")
+    schema_payload = {"features": [{"name": "user_id"}]}
+    (checkpoint_dir / "schema.json").write_text(json.dumps(schema_payload), encoding="utf-8")
     _write_train_config(checkpoint_dir, {"batch_size": 96, "num_workers": 4})
     captured: dict[str, object] = {}
 
@@ -103,6 +105,8 @@ def test_infer_uses_train_config_runtime_settings(tmp_path: Path, monkeypatch: p
     assert captured["num_workers"] == 4
     assert payload["batch_size"] == 96
     assert payload["num_workers"] == 4
+    assert payload["schema_path"] == str((checkpoint_dir / "schema.json").resolve())
+    assert payload["schema"] == schema_payload
     assert json.loads((tmp_path / "results" / "predictions.json").read_text(encoding="utf-8")) == {
         "predictions": {"u1": 0.5},
     }
@@ -149,6 +153,7 @@ def test_infer_uses_train_config_runtime_execution(tmp_path: Path, monkeypatch: 
     checkpoint_dir = tmp_path / "checkpoint"
     checkpoint_dir.mkdir()
     (checkpoint_dir / "model.pt").write_bytes(b"checkpoint")
+    (checkpoint_dir / "schema.json").write_text(json.dumps({"features": []}), encoding="utf-8")
     _write_train_config(checkpoint_dir, {"amp": True, "amp_dtype": "float16", "compile": True})
     captured: dict[str, object] = {}
 
@@ -180,6 +185,8 @@ def test_evaluate_writes_score_diagnostics(tmp_path: Path, monkeypatch: pytest.M
     checkpoint_dir.mkdir()
     checkpoint_path = checkpoint_dir / "model.pt"
     checkpoint_path.write_bytes(b"checkpoint")
+    schema_payload = {"features": [{"name": "label"}]}
+    (checkpoint_dir / "schema.json").write_text(json.dumps(schema_payload), encoding="utf-8")
     _write_train_config(checkpoint_dir)
 
     def fake_bound_run_prediction_loop(self, **kwargs):
@@ -217,9 +224,12 @@ def test_evaluate_writes_score_diagnostics(tmp_path: Path, monkeypatch: pytest.M
     assert diagnostics["score_margin_mean"] == pytest.approx(0.7)
     assert payload["metrics"]["auc_ci"]["low"] <= payload["metrics"]["auc"] <= payload["metrics"]["auc_ci"]["high"]
     assert payload["data_diagnostics"]["row_group_split"]["is_l1_ready"] is True
+    assert payload["schema_path"] == str((checkpoint_dir / "schema.json").resolve())
+    assert payload["schema"] == schema_payload
     saved_payload = json.loads(output_path.read_text(encoding="utf-8"))
     assert saved_payload["metrics"]["score_diagnostics"] == diagnostics
     assert saved_payload["data_diagnostics"] == payload["data_diagnostics"]
+    assert saved_payload["schema"] == schema_payload
 
 
 def test_infer_request_runtime_settings_override_train_config(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #66.

## Summary
- include the resolved schema path and schema payload in PCVR eval/infer results so the CLI prints the actual schema being used
- keep taac-evaluate `--json` output compact on a single line so the schema payload stays inline instead of being pretty-printed
- add focused tests for the payload fields and compact CLI JSON output

## Validation
- uv run pytest tests/unit/test_pcvr_infer_runtime.py tests/unit/test_evaluation_cli.py -q
- uv run taac-evaluate single --experiment config/baseline --dataset-path data/sample_1000_raw --schema-path data/sample_1000_raw/schema.json --run-dir /tmp/taac-issue66-train-bnyXOZ --device cpu --batch-size 32 --num-workers 0 --no-amp --no-compile --json | sed -n '1p'
