### PR TITLE
feat: 迁移 checkpoint 到 safetensors 格式

### DIFF
--- a/.agents/skills/pcvr-experiment-integration/SKILL.md
+++ b/.agents/skills/pcvr-experiment-integration/SKILL.md
@@ -141,7 +141,7 @@ Online training bundles should remain the platform two-file shape:
 - `run.sh`
 - `code_package.zip`
 
-The code package should include `src/taac2026`, `pyproject.toml`, `uv.lock` when present, and the selected experiment package including `model.py` and `ns_groups.json`.
+The code package should include `src/taac2026`, `pyproject.toml`, and the selected experiment package including `model.py` and `ns_groups.json`.
 
 ## Official Baseline Snapshot Notes
 
@@ -149,11 +149,11 @@ Official baseline source snapshots are disposable references only. Read them for
 
 The official self-contained training baseline contains `run.sh`, a training entrypoint, a trainer, utilities, dataset code, model code, and `ns_groups.json`. Its active `run.sh` used `ns_tokenizer_type=rankmixer`, `user_ns_tokens=5`, `item_ns_tokens=2`, `num_queries=2`, `ns_groups_json=""`, `emb_skip_threshold=1000000`, and `num_workers=8`. The commented group-tokenizer alternative uses `ns_groups.json` with `num_queries=1` because `rank_mixer_mode=full` requires `d_model % (num_queries * num_sequences + num_ns) == 0`.
 
-The official scoring baseline shares the same dataset and model definitions as the training snapshot. Its `infer.py` rebuilds `PCVRHyFormer` from checkpoint-side `schema.json`, optional `ns_groups.json`, and `train_config.json`, then strictly loads `model.pt` and writes `predictions.json` as `{"predictions": {user_id: probability}}`.
+The official scoring baseline shares the same dataset and model definitions as the training snapshot. Its `infer.py` rebuilds `PCVRHyFormer` from checkpoint-side `schema.json`, optional `ns_groups.json`, and `train_config.json`, then strictly loads `model.safetensors` and writes `predictions.json` as `{"predictions": {user_id: probability}}`.
 
 When adapting this snapshot into `config/baseline`, keep the model body local but adapt the public constructor to the shared contract. In particular, the official `num_hyformer_blocks` argument maps to the shared `num_blocks` argument, and the experiment package should own `ns_groups.json` even when a historical `run.sh` disabled the file for one rankmixer run.
 
-Checkpoint sidecars are part of the model contract, not optional convenience files. Training must persist `model.pt`, `schema.json`, `train_config.json`, and the resolved `ns_groups.json` when grouping is enabled, because evaluation/inference use those files as the source of truth for model reconstruction.
+Checkpoint sidecars are part of the model contract, not optional convenience files. Training must persist `model.safetensors`, `schema.json`, `train_config.json`, and the resolved `ns_groups.json` when grouping is enabled, because evaluation/inference use those files as the source of truth for model reconstruction.
 
 ## Tests to Update
 

--- a/.agents/skills/taac-competition-environment/SKILL.md
+++ b/.agents/skills/taac-competition-environment/SKILL.md
@@ -100,7 +100,7 @@ The package command calls `taac-package-train`, which writes:
 - `run.sh`: copied from the repository root and marked executable.
 - `code_package.zip`: minimal runtime source tree.
 
-The zip contains `project/.taac_training_manifest.json`, `pyproject.toml`, `uv.lock`, `README.md` when present, `src/taac2026`, and only the selected experiment package under `config/<experiment>`. It must not include tests, docs, or unrelated experiment packages.
+The zip contains `project/.taac_training_manifest.json`, `pyproject.toml`, `src/taac2026`, and only the selected experiment package under `config/<experiment>`. It must not include tests, docs, unrelated experiment packages, or local provenance files such as `uv.lock` and `README.md`.
 
 ## Official Baseline Snapshots
 
@@ -113,7 +113,7 @@ Treat these sources as disposable references. Extract the contracts, update repo
 
 The official training snapshot reads `TRAIN_DATA_PATH`, `TRAIN_CKPT_PATH`, `TRAIN_LOG_PATH`, and `TRAIN_TF_EVENTS_PATH`. The official scoring snapshot reads `MODEL_OUTPUT_PATH`, `EVAL_DATA_PATH`, and `EVAL_RESULT_PATH`, then writes `predictions.json` under `EVAL_RESULT_PATH` with the shape `{"predictions": {user_id: probability}}`.
 
-The important portable contract between training and scoring is the checkpoint directory. It must contain `model.pt`, `schema.json`, `train_config.json`, and `ns_groups.json` when grouping was enabled. Evaluation rebuilds the model from these sidecars and loads the state dict strictly, so missing or stale sidecars usually cause shape mismatches rather than a recoverable warning.
+The important portable contract between training and scoring is the checkpoint directory. It must contain `model.safetensors`, `schema.json`, `train_config.json`, and `ns_groups.json` when grouping was enabled. Evaluation rebuilds the model from these sidecars and loads the state dict strictly, so missing or stale sidecars usually cause shape mismatches rather than a recoverable warning.
 
 ## Online Conda + pip / Python Runtime
 
@@ -132,7 +132,7 @@ Dependency responsibility online:
 - Prefer the platform or image-provided CUDA, PyTorch, FBGEMM, and TorchRec stack.
 - Use Conda for the base Python/CUDA/PyTorch environment if the platform allows custom images or startup commands.
 - Use pip inside that Conda environment only for missing pure-Python packages that are not already available.
-- Do not call `uv sync` or require `uv.lock` online; `uv.lock` is packaged for provenance and local reproducibility, not online installation.
+- Do not call `uv sync` or require `uv.lock` online; `uv.lock` remains a local repository artifact for provenance and reproducibility and is not packaged into online bundles.
 
 If the platform image allows a pre-run dependency step, use the active Conda Python:
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ bash run.sh train --experiment config/baseline \
   --dataset-path /path/to/dataset_dir \
   --schema-path /path/to/dataset_dir/schema.json
 
-# 评估默认输出目录中的 best.pt；single 模式始终只评估一个实验/一个 checkpoint
+# 评估默认输出目录中的 best_model/model.safetensors；single 模式始终只评估一个实验/一个 checkpoint
 bash run.sh val --experiment config/baseline \
   --dataset-path /path/to/dataset_dir \
   --schema-path /path/to/dataset_dir/schema.json

--- a/config/host_device_info/runner.py
+++ b/config/host_device_info/runner.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import importlib.util
 import os
 import platform
+import re
 import shutil
 import socket
 import subprocess
@@ -278,18 +280,100 @@ def _log_python_info(sink: LogSink) -> None:
     sink.log(f"nvidia_visible_devices={os.environ.get('NVIDIA_VISIBLE_DEVICES', '<unset>')}")
 
 
+def _normalize_distribution_name(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _distribution_display_name(distribution: metadata.Distribution) -> str:
+    return distribution.metadata.get("Name") or distribution.name or "<unknown>"
+
+
+def _distribution_top_level_names(distribution: metadata.Distribution) -> tuple[str, ...]:
+    top_level = distribution.read_text("top_level.txt")
+    if top_level:
+        names = tuple(
+            dict.fromkeys(
+                line.strip()
+                for line in top_level.splitlines()
+                if line.strip()
+            )
+        )
+        if names:
+            return names
+
+    names: dict[str, None] = {}
+    for file in distribution.files or ():
+        parts = file.parts
+        if not parts:
+            continue
+        top_level_name = parts[0]
+        if top_level_name.endswith((".dist-info", ".egg-info", ".data")):
+            continue
+        module_name = top_level_name[:-3] if len(parts) == 1 and top_level_name.endswith(".py") else top_level_name
+        if module_name.isidentifier():
+            names[module_name] = None
+    return tuple(names)
+
+
+def _distribution_import_source(distribution: metadata.Distribution) -> str:
+    for import_name in _distribution_top_level_names(distribution):
+        try:
+            spec = importlib.util.find_spec(import_name)
+        except (AttributeError, ImportError, ValueError):
+            continue
+        if spec is None:
+            continue
+        if spec.submodule_search_locations:
+            location = next(iter(spec.submodule_search_locations), None)
+            if location:
+                return location
+        if spec.origin not in (None, "built-in", "frozen"):
+            return spec.origin
+    return str(distribution.locate_file(""))
+
+
+def _active_distribution_for_group(
+    distributions: Sequence[metadata.Distribution],
+) -> metadata.Distribution:
+    candidate_names: list[str] = []
+    for distribution in distributions:
+        for candidate_name in (_distribution_display_name(distribution), distribution.name):
+            if candidate_name and candidate_name not in candidate_names:
+                candidate_names.append(candidate_name)
+    for candidate_name in candidate_names:
+        try:
+            return metadata.distribution(candidate_name)
+        except metadata.PackageNotFoundError:
+            continue
+    return distributions[0]
+
+
 def _log_python_packages(sink: LogSink) -> None:
     sink.log("---- python packages ----")
+    grouped_distributions: dict[str, list[metadata.Distribution]] = {}
+    for distribution in metadata.distributions():
+        grouped_distributions.setdefault(
+            _normalize_distribution_name(_distribution_display_name(distribution)),
+            [],
+        ).append(distribution)
+
     packages = sorted(
         (
-            (distribution.metadata.get("Name") or distribution.name or "<unknown>", distribution.version)
-            for distribution in metadata.distributions()
+            (
+                _distribution_display_name(active_distribution),
+                active_distribution.version,
+                _distribution_import_source(active_distribution),
+            )
+            for active_distribution in (
+                _active_distribution_for_group(distributions)
+                for distributions in grouped_distributions.values()
+            )
         ),
         key=lambda item: item[0].lower(),
     )
     sink.log(f"installed_python_packages={len(packages)}")
-    for name, version in packages:
-        sink.log(f"{name}=={version}")
+    for name, version, source in packages:
+        sink.log(f"{name}=={version} source={source}")
 
 
 def _log_uv_bootstrap_status(sink: LogSink, config: HostDeviceInfoConfig) -> None:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -151,7 +151,7 @@ NS（Non-Sequential）Groups 将非序列特征 ID 映射到语义分组，供 N
 2. **AMP** -- 可选混合精度训练，支持 `bfloat16` / `float16`
 3. **`torch.compile`** -- 可选 JIT 编译加速
 4. **Early Stopping** -- 基于验证集 AUC
-5. **Checkpoint** -- 保存 `model.pt` + 侧车文件（`schema.json`、`ns_groups.json`、`train_config.json`）
+5. **Checkpoint** -- 保存 `model.safetensors` + 侧车文件（`schema.json`、`ns_groups.json`、`train_config.json`）
 6. **高基数 Embedding 重初始化** -- 每个 epoch 后重初始化低频特征的 Embedding
 
 损失函数（在 `infrastructure/training/runtime.py`）：
@@ -186,7 +186,7 @@ NS（Non-Sequential）Groups 将非序列特征 ID 映射到语义分组，供 N
 run.sh                    # 自动检测 Bundle / 本地模式
 code_package.zip
 ├── .taac_training_manifest.json
-├── pyproject.toml + uv.lock
+├── pyproject.toml
 ├── src/taac2026/
 ├── config/<experiment>/
 └── tools/
@@ -198,7 +198,7 @@ code_package.zip
 infer.py                  # 自解压 + 安装 + 推理脚本
 code_package.zip
 ├── .taac_inference_manifest.json
-├── pyproject.toml + uv.lock
+├── pyproject.toml
 ├── src/taac2026/
 ├── config/<experiment>/
 └── <checkpoint>/

--- a/docs/experiments/baseline.md
+++ b/docs/experiments/baseline.md
@@ -48,7 +48,7 @@ uv run taac-train \
 ```
 outputs/pcvr_baseline-<slug>/
 ├── global_step<N>.{params}.best_model/
-│   ├── model.pt
+│   ├── model.safetensors
 │   ├── schema.json
 │   ├── ns_groups.json
 │   └── train_config.json

--- a/docs/experiments/index.md
+++ b/docs/experiments/index.md
@@ -8,6 +8,8 @@ icon: lucide/folder-open
 
 ## 当前实验包
 
+### 模型训练包
+
 | 实验包         | 模型类         | Blocks | Dropout | NS Tokenizer      | 亮点                             |
 | -------------- | -------------- | ------ | ------- | ----------------- | -------------------------------- |
 | Baseline       | HyFormer       | 默认   | 默认    | group             | 基准参考                         |
@@ -20,9 +22,18 @@ icon: lucide/folder-open
 | UniRec         | UniRec         | 3      | 0.02    | rankmixer (5u/2i) | 统一推荐                         |
 | UniScaleFormer | UniScaleFormer | 4      | 0.02    | rankmixer (5u/2i) | 最深栈                           |
 
+### 维护工具包
+
+| 实验包             | 用途             | 需要数据集 | 说明                               |
+| ------------------ | ---------------- | ---------- | ---------------------------------- |
+| Host Device Info   | 主机设备诊断采集 | 否         | 采集 GPU、网络、依赖源等环境快照   |
+| Online Dataset EDA | 数据集探索分析   | 是         | 流式 Parquet 统计，线上友好        |
+
 ## 包内文件
 
-每个实验包目录必须包含三个文件：
+### 模型训练包
+
+每个模型训练包目录包含三个文件：
 
 ```
 config/<experiment_name>/
@@ -56,6 +67,19 @@ EXPERIMENT = PCVRExperiment(
 | `reinit_high_cardinality_params` | `() -> None`                           | 重初始化低频 Embedding |
 
 **`ns_groups.json`** 定义 NS 特征分组，格式见 [架构与概念](../architecture.md#ns-groups)。
+
+### 维护工具包
+
+维护工具包使用 `ExperimentSpec` 而非 `PCVRExperiment`，不需要模型定义和 NS 分组：
+
+```
+config/<tool_name>/
+├── __init__.py         # EXPERIMENT = ExperimentSpec(name, package_dir, train_fn, metadata)
+└── runner.py           # 工具逻辑实现
+```
+
+- [Host Device Info](host-device-info.md) -- 主机与设备诊断采集
+- [Online Dataset EDA](online-dataset-eda.md) -- 数据集探索性分析
 
 ## 运行任意实验包
 

--- a/docs/guide/competition-online-server.md
+++ b/docs/guide/competition-online-server.md
@@ -151,7 +151,7 @@ bash run.sh --device cuda
 设计约束：
 
 - `code_package.zip` 应包含运行代码和选中的实验包，不依赖线上 `uv sync`。
-- `uv.lock` 可以随包保留用于追溯，但线上默认不使用它安装依赖。
+- `uv.lock` 只保留在仓库本地用于开发追溯，线上 bundle 不再包含它。
 - 缺少纯 Python 包时，先确认平台环境，再考虑用腾讯镜像补装。
 - 不要在任务启动时下载或覆盖核心 CUDA/PyTorch 栈。
 - 不要把旧训练栈里的 runtime optimization 参数复制到当前 PCVR CLI，当前共享 parser 不支持这些历史参数。

--- a/docs/guide/online-training-bundle.md
+++ b/docs/guide/online-training-bundle.md
@@ -30,8 +30,6 @@ outputs/bundle/
 code_package.zip
 ├── .taac_training_manifest.json   # Bundle 元信息
 ├── pyproject.toml                 # 依赖声明
-├── uv.lock                        # 依赖锁定
-├── README.md
 ├── config/__init__.py
 ├── config/<experiment>/           # 实验包
 │   ├── __init__.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
 	"pytest==9.0.3",
 	"pytest-benchmark==5.2.3",
 	"rich==14.3.3",
+	"safetensors==0.7.0",
 	"scikit-learn==1.7.2",
 	"tensorboard==2.19.0",
 	"tomli==2.4.0",

--- a/src/taac2026/application/maintenance/package_inference.py
+++ b/src/taac2026/application/maintenance/package_inference.py
@@ -178,7 +178,7 @@ def _write_code_package(
             "project/.taac_inference_manifest.json",
             dump_bytes(manifest, indent=2, trailing_newline=True),
         )
-        for filename in ("pyproject.toml", "uv.lock", "README.md"):
+        for filename in ("pyproject.toml",):
             source = root / filename
             if source.exists():
                 _add_file_to_zip(archive, source, f"project/{filename}")

--- a/src/taac2026/application/maintenance/package_training.py
+++ b/src/taac2026/application/maintenance/package_training.py
@@ -90,7 +90,7 @@ def _write_code_package(
             "project/.taac_training_manifest.json",
             dump_bytes(manifest, indent=2, trailing_newline=True),
         )
-        for filename in ("pyproject.toml", "uv.lock", "README.md"):
+        for filename in ("pyproject.toml",):
             source = root / filename
             if source.exists():
                 _add_file_to_zip(archive, source, f"project/{filename}")

--- a/src/taac2026/infrastructure/checkpoints.py
+++ b/src/taac2026/infrastructure/checkpoints.py
@@ -7,10 +7,67 @@ import shutil
 from pathlib import Path
 from typing import Any
 
+from safetensors.torch import load_file as load_safetensors_file, save_file as save_safetensors_file
+import torch
+
 from taac2026.infrastructure.io.json_utils import write_path
 
-
 _GLOBAL_STEP_PATTERN = re.compile(r"^global_step(?P<step>\d+)(?:[A-Za-z0-9_.=\-]*)$")
+PRIMARY_CHECKPOINT_FILENAME = "model.safetensors"
+_CHECKPOINT_SUFFIX = ".safetensors"
+
+
+def _is_supported_checkpoint_file(path: Path) -> bool:
+    return path.suffix == _CHECKPOINT_SUFFIX
+
+
+def _find_checkpoint_file(checkpoint_dir: Path) -> Path | None:
+    candidate = preferred_checkpoint_path(checkpoint_dir)
+    return candidate if candidate.exists() else None
+
+
+def preferred_checkpoint_path(checkpoint_dir: Path) -> Path:
+    return checkpoint_dir / PRIMARY_CHECKPOINT_FILENAME
+
+
+def _checkpoint_dir_from_path(checkpoint_path: Path) -> Path:
+    if _is_supported_checkpoint_file(checkpoint_path):
+        return checkpoint_path.parent
+    return checkpoint_path
+
+
+def _serialize_state_dict_for_safetensors(state_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+    serialized: dict[str, torch.Tensor] = {}
+    for key, value in state_dict.items():
+        if not isinstance(value, torch.Tensor):
+            raise TypeError(f"checkpoint state_dict entry must be a tensor: {key}")
+        serialized[key] = value.detach().cpu().contiguous()
+    return serialized
+
+
+def save_checkpoint_state_dict(
+    state_dict: dict[str, torch.Tensor],
+    checkpoint_path: Path,
+) -> Path:
+    checkpoint_dir = _checkpoint_dir_from_path(checkpoint_path.expanduser())
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+
+    primary_path = preferred_checkpoint_path(checkpoint_dir)
+    save_safetensors_file(_serialize_state_dict_for_safetensors(state_dict), str(primary_path))
+
+    return primary_path
+
+
+def load_checkpoint_state_dict(
+    checkpoint_path: Path,
+    *,
+    map_location: torch.device | str | None = None,
+) -> dict[str, torch.Tensor]:
+    resolved_checkpoint_path = checkpoint_path.expanduser().resolve()
+    if not _is_supported_checkpoint_file(resolved_checkpoint_path):
+        raise ValueError(f"unsupported checkpoint format: {resolved_checkpoint_path}")
+    device = "cpu" if map_location is None else str(map_location)
+    return load_safetensors_file(str(resolved_checkpoint_path), device=device)
 
 
 def validate_checkpoint_dir_name(name: str) -> None:
@@ -24,7 +81,7 @@ def validate_checkpoint_dir_name(name: str) -> None:
 
 
 def checkpoint_step(path: Path) -> int:
-    match = _GLOBAL_STEP_PATTERN.match(path.parent.name if path.name == "model.pt" else path.name)
+    match = _GLOBAL_STEP_PATTERN.match(path.parent.name if _is_supported_checkpoint_file(path) else path.name)
     if not match:
         return -1
     return int(match.group("step"))
@@ -34,28 +91,36 @@ def resolve_checkpoint_path(run_dir: Path, checkpoint_path: Path | None = None) 
     if checkpoint_path is not None:
         candidate = checkpoint_path.expanduser().resolve()
         if candidate.is_dir():
-            candidate = candidate / "model.pt"
+            resolved_candidate = _find_checkpoint_file(candidate)
+            if resolved_candidate is None:
+                raise FileNotFoundError(f"checkpoint not found in {candidate}; expected: {PRIMARY_CHECKPOINT_FILENAME}")
+            return resolved_candidate
+        if not _is_supported_checkpoint_file(candidate):
+            raise ValueError(f"unsupported checkpoint format: {candidate}")
         if not candidate.exists():
             raise FileNotFoundError(f"checkpoint not found: {candidate}")
         return candidate
 
     resolved_run_dir = run_dir.expanduser().resolve()
     best_candidates = sorted(
-        resolved_run_dir.glob("global_step*.best_model/model.pt"),
+        resolved_run_dir.glob(f"global_step*.best_model/{PRIMARY_CHECKPOINT_FILENAME}"),
         key=checkpoint_step,
     )
     if best_candidates:
         return best_candidates[-1]
 
-    all_candidates = sorted(resolved_run_dir.glob("global_step*/model.pt"), key=checkpoint_step)
+    all_candidates = sorted(
+        resolved_run_dir.glob(f"global_step*/{PRIMARY_CHECKPOINT_FILENAME}"),
+        key=checkpoint_step,
+    )
     if all_candidates:
         return all_candidates[-1]
 
-    direct_candidate = resolved_run_dir / "model.pt"
-    if direct_candidate.exists():
+    direct_candidate = _find_checkpoint_file(resolved_run_dir)
+    if direct_candidate is not None:
         return direct_candidate
 
-    raise FileNotFoundError(f"no model.pt checkpoint found under {resolved_run_dir}")
+    raise FileNotFoundError(f"no {PRIMARY_CHECKPOINT_FILENAME} checkpoint found under {resolved_run_dir}")
 
 
 def build_checkpoint_dir_name(global_step: int, checkpoint_params: dict[str, Any] | None = None, *, is_best: bool = False) -> str:

--- a/src/taac2026/infrastructure/checkpoints.py
+++ b/src/taac2026/infrastructure/checkpoints.py
@@ -15,10 +15,15 @@ from taac2026.infrastructure.io.json_utils import write_path
 _GLOBAL_STEP_PATTERN = re.compile(r"^global_step(?P<step>\d+)(?:[A-Za-z0-9_.=\-]*)$")
 PRIMARY_CHECKPOINT_FILENAME = "model.safetensors"
 _CHECKPOINT_SUFFIX = ".safetensors"
+_LEGACY_CHECKPOINT_SUFFIXES = frozenset({".pt", ".pth"})
 
 
 def _is_supported_checkpoint_file(path: Path) -> bool:
-    return path.suffix == _CHECKPOINT_SUFFIX
+    return path.suffix.lower() == _CHECKPOINT_SUFFIX
+
+
+def _is_legacy_checkpoint_file(path: Path) -> bool:
+    return path.suffix.lower() in _LEGACY_CHECKPOINT_SUFFIXES
 
 
 def _find_checkpoint_file(checkpoint_dir: Path) -> Path | None:
@@ -33,6 +38,8 @@ def preferred_checkpoint_path(checkpoint_dir: Path) -> Path:
 def _checkpoint_dir_from_path(checkpoint_path: Path) -> Path:
     if _is_supported_checkpoint_file(checkpoint_path):
         return checkpoint_path.parent
+    if _is_legacy_checkpoint_file(checkpoint_path):
+        raise ValueError(f"unsupported checkpoint format: {checkpoint_path}")
     return checkpoint_path
 
 

--- a/src/taac2026/infrastructure/pcvr/experiment.py
+++ b/src/taac2026/infrastructure/pcvr/experiment.py
@@ -18,7 +18,7 @@ from torch.utils.data import DataLoader
 
 from taac2026.domain.config import EvalRequest, InferRequest, TrainRequest
 from taac2026.domain.metrics import compute_classification_metrics
-from taac2026.infrastructure.checkpoints import resolve_checkpoint_path
+from taac2026.infrastructure.checkpoints import load_checkpoint_state_dict, resolve_checkpoint_path
 from taac2026.infrastructure.io.files import read_json, write_json
 from taac2026.infrastructure.io.json_utils import dump_bytes
 import taac2026.infrastructure.pcvr.data as pcvr_data
@@ -469,7 +469,7 @@ class PCVRExperiment:
         runtime_device = torch.device(device)
         resolved_runtime_execution = runtime_execution or RuntimeExecutionConfig()
         model.to(runtime_device)
-        state_dict = torch.load(checkpoint_path, map_location=runtime_device)
+        state_dict = load_checkpoint_state_dict(checkpoint_path, map_location=runtime_device)
         model.load_state_dict(state_dict)
         model.eval()
         predict_fn = maybe_compile_callable(

--- a/src/taac2026/infrastructure/pcvr/trainer.py
+++ b/src/taac2026/infrastructure/pcvr/trainer.py
@@ -226,7 +226,6 @@ class PCVRPointwiseTrainer:
         skip_model_file: bool = False,
     ) -> Path:
         checkpoint_dir = self.save_dir / self._build_step_dir_name(global_step, is_best=is_best)
-        checkpoint_dir.mkdir(parents=True, exist_ok=True)
         if not skip_model_file:
             save_checkpoint_state_dict(self.model.state_dict(), checkpoint_dir)
         self._write_sidecar_files(checkpoint_dir)

--- a/src/taac2026/infrastructure/pcvr/trainer.py
+++ b/src/taac2026/infrastructure/pcvr/trainer.py
@@ -19,7 +19,12 @@ from torch.utils.data import DataLoader
 from tqdm import tqdm
 
 from taac2026.domain.metrics import binary_score_diagnostics
-from taac2026.infrastructure.checkpoints import build_checkpoint_dir_name, write_checkpoint_sidecars
+from taac2026.infrastructure.checkpoints import (
+    build_checkpoint_dir_name,
+    preferred_checkpoint_path,
+    save_checkpoint_state_dict,
+    write_checkpoint_sidecars,
+)
 from taac2026.infrastructure.pcvr.protocol import batch_to_model_input
 from taac2026.infrastructure.pcvr.tensors import sigmoid_probabilities_numpy
 from taac2026.infrastructure.training.runtime import (
@@ -223,9 +228,9 @@ class PCVRPointwiseTrainer:
         checkpoint_dir = self.save_dir / self._build_step_dir_name(global_step, is_best=is_best)
         checkpoint_dir.mkdir(parents=True, exist_ok=True)
         if not skip_model_file:
-            torch.save(self.model.state_dict(), checkpoint_dir / "model.pt")
+            save_checkpoint_state_dict(self.model.state_dict(), checkpoint_dir)
         self._write_sidecar_files(checkpoint_dir)
-        logging.info("Saved checkpoint to %s", checkpoint_dir / "model.pt")
+        logging.info("Saved checkpoint to %s", preferred_checkpoint_path(checkpoint_dir))
         return checkpoint_dir
 
     def _remove_old_best_dirs(self) -> None:
@@ -262,7 +267,7 @@ class PCVRPointwiseTrainer:
             return
 
         best_dir = self.save_dir / self._build_step_dir_name(total_step, is_best=True)
-        self.early_stopping.checkpoint_path = str(best_dir / "model.pt")
+        self.early_stopping.checkpoint_path = str(preferred_checkpoint_path(best_dir))
         self._remove_old_best_dirs()
 
         self.early_stopping(val_auc, self.model, {

--- a/src/taac2026/infrastructure/pcvr/training.py
+++ b/src/taac2026/infrastructure/pcvr/training.py
@@ -403,7 +403,7 @@ def train_pcvr_model(
         logging.info("Total parameters: %s", f"{total_params:,}")
 
         early_stopping = EarlyStopping(
-            checkpoint_path=ckpt_dir / "placeholder" / "model.pt",
+            checkpoint_path=ckpt_dir / "placeholder" / "model.safetensors",
             patience=args.patience,
             label="model",
         )

--- a/src/taac2026/infrastructure/training/runtime.py
+++ b/src/taac2026/infrastructure/training/runtime.py
@@ -241,7 +241,6 @@ class EarlyStopping:
         if self.verbose:
             logging.info("Validation score increased. Saving model ...")
         checkpoint_path = Path(self.checkpoint_path)
-        checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
         save_checkpoint_state_dict(model.state_dict(), checkpoint_path)
         self.best_saved_score = score
 

--- a/src/taac2026/infrastructure/training/runtime.py
+++ b/src/taac2026/infrastructure/training/runtime.py
@@ -18,6 +18,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from taac2026.infrastructure.checkpoints import save_checkpoint_state_dict
+
 
 AMP_DTYPE_CHOICES: tuple[str, ...] = ("bfloat16", "float16")
 BINARY_LOSS_TYPE_CHOICES: tuple[str, ...] = ("bce", "focal")
@@ -240,7 +242,7 @@ class EarlyStopping:
             logging.info("Validation score increased. Saving model ...")
         checkpoint_path = Path(self.checkpoint_path)
         checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
-        torch.save(model.state_dict(), checkpoint_path)
+        save_checkpoint_state_dict(model.state_dict(), checkpoint_path)
         self.best_saved_score = score
 
 

--- a/tests/unit/test_checkpoint_and_loader.py
+++ b/tests/unit/test_checkpoint_and_loader.py
@@ -82,6 +82,13 @@ def test_save_and_load_checkpoint_state_dict_round_trip(tmp_path: Path) -> None:
     assert torch.equal(loaded_state_dict["bias"], state_dict["bias"])
 
 
+def test_save_checkpoint_rejects_legacy_pt_path(tmp_path: Path) -> None:
+    state_dict = {"weight": torch.arange(2, dtype=torch.float32)}
+
+    with pytest.raises(ValueError, match=r"unsupported checkpoint format"):
+        save_checkpoint_state_dict(state_dict, tmp_path / "legacy.pt")
+
+
 def test_load_baseline_experiment_from_path() -> None:
     experiment = load_experiment_package("config/baseline")
 

--- a/tests/unit/test_checkpoint_and_loader.py
+++ b/tests/unit/test_checkpoint_and_loader.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import torch
 
 from taac2026.infrastructure.checkpoints import (
+    PRIMARY_CHECKPOINT_FILENAME,
     build_checkpoint_dir_name,
+    load_checkpoint_state_dict,
     resolve_checkpoint_path,
+    save_checkpoint_state_dict,
     validate_checkpoint_dir_name,
     write_checkpoint_sidecars,
 )
@@ -18,10 +22,19 @@ def test_resolve_checkpoint_prefers_best_model(tmp_path: Path) -> None:
     best_dir = tmp_path / "global_step2.layer=2.best_model"
     old_dir.mkdir()
     best_dir.mkdir()
-    (old_dir / "model.pt").write_text("old", encoding="utf-8")
-    (best_dir / "model.pt").write_text("best", encoding="utf-8")
+    (old_dir / PRIMARY_CHECKPOINT_FILENAME).write_text("old", encoding="utf-8")
+    (best_dir / PRIMARY_CHECKPOINT_FILENAME).write_text("best", encoding="utf-8")
 
-    assert resolve_checkpoint_path(tmp_path) == best_dir / "model.pt"
+    assert resolve_checkpoint_path(tmp_path) == best_dir / PRIMARY_CHECKPOINT_FILENAME
+
+
+def test_resolve_checkpoint_rejects_legacy_pt_files(tmp_path: Path) -> None:
+    legacy_path = tmp_path / "global_step2.layer=2.best_model" / "legacy.pt"
+    legacy_path.parent.mkdir()
+    legacy_path.write_text("legacy", encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"unsupported checkpoint format"):
+        resolve_checkpoint_path(tmp_path, legacy_path)
 
 
 def test_validate_checkpoint_name_rejects_non_global_step_prefix() -> None:
@@ -50,6 +63,23 @@ def test_write_checkpoint_sidecars_rewrites_ns_groups_path(tmp_path: Path) -> No
     assert set(written) == {"schema", "ns_groups", "train_config"}
     assert (checkpoint_dir / "schema.json").exists()
     assert '"ns_groups_json": "ns_groups.json"' in (checkpoint_dir / "train_config.json").read_text(encoding="utf-8")
+
+
+def test_save_and_load_checkpoint_state_dict_round_trip(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "global_step3.best_model"
+    state_dict = {
+        "weight": torch.arange(6, dtype=torch.float32).reshape(2, 3),
+        "bias": torch.tensor([1.5], dtype=torch.float32),
+    }
+
+    checkpoint_path = save_checkpoint_state_dict(state_dict, checkpoint_dir)
+
+    assert checkpoint_path == checkpoint_dir / PRIMARY_CHECKPOINT_FILENAME
+    assert not any(checkpoint_dir.glob("*.pt"))
+
+    loaded_state_dict = load_checkpoint_state_dict(checkpoint_path, map_location="cpu")
+    assert torch.equal(loaded_state_dict["weight"], state_dict["weight"])
+    assert torch.equal(loaded_state_dict["bias"], state_dict["bias"])
 
 
 def test_load_baseline_experiment_from_path() -> None:

--- a/tests/unit/test_evaluation_cli.py
+++ b/tests/unit/test_evaluation_cli.py
@@ -28,7 +28,7 @@ def test_parse_eval_args_accepts_runtime_flags() -> None:
 
 def test_main_output_is_compact_single_line(monkeypatch, capsys) -> None:
     payload = {
-        "checkpoint_path": "/tmp/model.pt",
+        "checkpoint_path": "/tmp/model.safetensors",
         "schema_path": "/tmp/schema.json",
         "schema": {"features": [{"name": "user_id"}]},
     }

--- a/tests/unit/test_maintenance_experiments.py
+++ b/tests/unit/test_maintenance_experiments.py
@@ -4,6 +4,7 @@ from dataclasses import replace
 import importlib.util
 from pathlib import Path
 import sys
+from types import SimpleNamespace
 
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -146,6 +147,129 @@ def test_host_device_info_runner_converts_timeout_to_failure_result() -> None:
 
     assert return_code == runner_module.TIMEOUT_EXIT_CODE
     assert "timed out" in output
+
+
+def test_host_device_info_runner_logs_deduplicated_active_python_packages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner_module = _load_host_device_info_runner_module()
+    messages: list[str] = []
+
+    class FakeSink:
+        def close(self) -> None:
+            return None
+
+        def log(self, message: str) -> None:
+            messages.append(message)
+
+    class FakeDistribution:
+        def __init__(self, name: str, version: str, root: str, top_levels: tuple[str, ...]) -> None:
+            self.metadata = {"Name": name}
+            self.name = name
+            self.version = version
+            self.files = [Path(f"{top_level}/__init__.py") for top_level in top_levels]
+            self._root = Path(root)
+            self._top_levels = top_levels
+
+        def read_text(self, filename: str) -> str | None:
+            if filename != "top_level.txt":
+                return None
+            return "\n".join(self._top_levels)
+
+        def locate_file(self, path: str) -> Path:
+            return self._root / path
+
+    active_distributions = {
+        "numpy": FakeDistribution("numpy", "2.2.6", "/env/new/site-packages", ("numpy",)),
+        "Pillow": FakeDistribution("Pillow", "12.2.0", "/env/new/site-packages", ("PIL",)),
+        "torch": FakeDistribution("torch", "2.7.1", "/env/site-packages", ("torch",)),
+    }
+    discovered_distributions = [
+        FakeDistribution("numpy", "2.2.5", "/env/old/site-packages", ("numpy",)),
+        active_distributions["numpy"],
+        FakeDistribution("Pillow", "12.1.1", "/env/old/site-packages", ("PIL",)),
+        active_distributions["Pillow"],
+        active_distributions["torch"],
+    ]
+
+    def fake_distribution(name: str):
+        try:
+            return active_distributions[name]
+        except KeyError as error:
+            raise runner_module.metadata.PackageNotFoundError(name) from error
+
+    def fake_find_spec(name: str):
+        specs = {
+            "numpy": SimpleNamespace(submodule_search_locations=["/env/new/site-packages/numpy"], origin=None),
+            "PIL": SimpleNamespace(submodule_search_locations=["/env/new/site-packages/PIL"], origin=None),
+            "torch": SimpleNamespace(submodule_search_locations=["/env/site-packages/torch"], origin=None),
+        }
+        return specs.get(name)
+
+    monkeypatch.setattr(runner_module.metadata, "distributions", lambda: iter(discovered_distributions))
+    monkeypatch.setattr(runner_module.metadata, "distribution", fake_distribution)
+    monkeypatch.setattr(runner_module.importlib.util, "find_spec", fake_find_spec)
+
+    runner_module._log_python_packages(FakeSink())
+
+    assert messages[0] == "---- python packages ----"
+    assert "installed_python_packages=3" in messages
+    assert "numpy==2.2.6 source=/env/new/site-packages/numpy" in messages
+    assert "Pillow==12.2.0 source=/env/new/site-packages/PIL" in messages
+    assert "torch==2.7.1 source=/env/site-packages/torch" in messages
+    assert all("2.2.5" not in message for message in messages)
+    assert all("12.1.1" not in message for message in messages)
+
+
+def test_host_device_info_runner_continues_after_unexpected_section_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner_module = _load_host_device_info_runner_module()
+    events: list[str] = []
+    messages: list[str] = []
+
+    class FakeSink:
+        def close(self) -> None:
+            messages.append("__closed__")
+
+        def log(self, message: str) -> None:
+            messages.append(message)
+
+    def record(name: str):
+        def _handler(*args, **kwargs) -> None:
+            events.append(name)
+
+        return _handler
+
+    def fail_conda_search(*args, **kwargs) -> None:
+        events.append("conda_search_probes")
+        raise RuntimeError("conda probe exploded")
+
+    monkeypatch.setattr(runner_module, "LogSink", FakeSink)
+    monkeypatch.setattr(runner_module, "_log_os_release", record("os_release"))
+    monkeypatch.setattr(runner_module, "_log_proxy_environment", record("proxy_environment"))
+    monkeypatch.setattr(runner_module, "_log_command", lambda sink, title, command, timeout=None: events.append(title))
+    monkeypatch.setattr(runner_module, "_log_network_info", record("network"))
+    monkeypatch.setattr(runner_module, "_log_device_nodes", lambda sink, pattern, title, missing_message: events.append(title))
+    monkeypatch.setattr(runner_module, "_log_uv_bootstrap_status", record("uv_bootstrap"))
+    monkeypatch.setattr(runner_module, "_log_dependency_index_status", record("dependency_indexes"))
+    monkeypatch.setattr(runner_module, "_log_connectivity_matrix", record("connectivity_matrix"))
+    monkeypatch.setattr(runner_module, "_log_pip_download_probes", record("pip_download_probes"))
+    monkeypatch.setattr(runner_module, "_log_conda_search_probes", fail_conda_search)
+    monkeypatch.setattr(runner_module, "_log_build_tools", record("build_tools"))
+    monkeypatch.setattr(runner_module, "_log_python_info", record("python_info"))
+    monkeypatch.setattr(runner_module, "_log_python_packages", record("python_packages"))
+
+    summary = runner_module.collect_host_device_info(runner_module.HostDeviceInfoConfig(repo_root=REPO_ROOT))
+
+    assert summary["repo_root"] == str(REPO_ROOT)
+    assert "conda_search_probes" in events
+    assert "build_tools" in events
+    assert "python_info" in events
+    assert "python_packages" in events
+    assert any("conda_search_probes_failure_class=RuntimeError" in message for message in messages)
+    assert any("conda_search_probes_failure_detail=conda probe exploded" in message for message in messages)
+    assert messages[-1] == "__closed__"
 
 
 def test_online_dataset_eda_experiment_prints_report_to_stdout(

--- a/tests/unit/test_package_inference.py
+++ b/tests/unit/test_package_inference.py
@@ -103,7 +103,8 @@ def test_build_inference_bundle_contains_runtime_sources(tmp_path: Path) -> None
     names = _code_package_names(result.code_package_path)
     assert "project/.taac_inference_manifest.json" in names
     assert "project/pyproject.toml" in names
-    assert "project/uv.lock" in names
+    assert "project/uv.lock" not in names
+    assert "project/README.md" not in names
     assert "project/src/taac2026/application/evaluation/cli.py" in names
     assert "project/src/taac2026/application/evaluation/infer.py" in names
     assert "project/config/baseline/model.py" in names

--- a/tests/unit/test_package_training.py
+++ b/tests/unit/test_package_training.py
@@ -109,7 +109,8 @@ def test_build_training_bundle_contains_runtime_sources(tmp_path: Path) -> None:
     names = _code_package_names(result.code_package_path)
     assert "project/.taac_training_manifest.json" in names
     assert "project/pyproject.toml" in names
-    assert "project/uv.lock" in names
+    assert "project/uv.lock" not in names
+    assert "project/README.md" not in names
     assert "project/src/taac2026/application/training/cli.py" in names
     assert "project/src/taac2026/infrastructure/pcvr/training.py" in names
     assert "project/src/taac2026/infrastructure/pcvr/trainer.py" in names

--- a/tests/unit/test_pcvr_infer_runtime.py
+++ b/tests/unit/test_pcvr_infer_runtime.py
@@ -199,7 +199,7 @@ def test_run_prediction_loop_loads_safetensors_via_checkpoint_helper(
         def __init__(self) -> None:
             self.loaded_state_dict = None
 
-        def to(self, device) -> "FakeModel":
+        def to(self, device) -> FakeModel:
             del device
             return self
 

--- a/tests/unit/test_pcvr_infer_runtime.py
+++ b/tests/unit/test_pcvr_infer_runtime.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
 from taac2026.domain.config import EvalRequest, InferRequest
 from taac2026.infrastructure.io.json_utils import dumps, loads
 from taac2026.infrastructure.pcvr.config import PCVRDataConfig, PCVRTrainConfig
+import taac2026.infrastructure.pcvr.experiment as experiment_module
 from taac2026.infrastructure.pcvr.experiment import PCVRExperiment, _log_prediction_progress
 from taac2026.infrastructure.training.runtime import RuntimeExecutionConfig
 
@@ -74,7 +76,7 @@ def test_infer_uses_train_config_runtime_settings(tmp_path: Path, monkeypatch: p
     )
     checkpoint_dir = tmp_path / "checkpoint"
     checkpoint_dir.mkdir()
-    (checkpoint_dir / "model.pt").write_bytes(b"checkpoint")
+    (checkpoint_dir / "model.safetensors").write_bytes(b"checkpoint")
     schema_payload = {"features": [{"name": "user_id"}]}
     (checkpoint_dir / "schema.json").write_text(dumps(schema_payload), encoding="utf-8")
     _write_train_config(checkpoint_dir, {"batch_size": 96, "num_workers": 4})
@@ -152,7 +154,7 @@ def test_infer_uses_train_config_runtime_execution(tmp_path: Path, monkeypatch: 
     experiment = _make_experiment(tmp_path)
     checkpoint_dir = tmp_path / "checkpoint"
     checkpoint_dir.mkdir()
-    (checkpoint_dir / "model.pt").write_bytes(b"checkpoint")
+    (checkpoint_dir / "model.safetensors").write_bytes(b"checkpoint")
     (checkpoint_dir / "schema.json").write_text(dumps({"features": []}), encoding="utf-8")
     _write_train_config(checkpoint_dir, {"amp": True, "amp_dtype": "float16", "compile": True})
     captured: dict[str, object] = {}
@@ -179,11 +181,76 @@ def test_infer_uses_train_config_runtime_execution(tmp_path: Path, monkeypatch: 
     assert runtime_execution == RuntimeExecutionConfig(amp=True, amp_dtype="float16", compile=True)
 
 
+def test_run_prediction_loop_loads_safetensors_via_checkpoint_helper(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    experiment = _make_experiment(tmp_path)
+    checkpoint_dir = tmp_path / "checkpoint"
+    checkpoint_dir.mkdir()
+    checkpoint_path = checkpoint_dir / "model.safetensors"
+    checkpoint_path.write_bytes(b"checkpoint")
+    loaded_state_dict = {"weight": object()}
+
+    class FakeDataset:
+        num_rows = 0
+
+    class FakeModel:
+        def __init__(self) -> None:
+            self.loaded_state_dict = None
+
+        def to(self, device) -> "FakeModel":
+            del device
+            return self
+
+        def load_state_dict(self, state_dict) -> None:
+            self.loaded_state_dict = state_dict
+
+        def eval(self) -> None:
+            return None
+
+        def predict(self, model_input):
+            del model_input
+            raise AssertionError("predict should not run when loader is empty")
+
+    fake_model = FakeModel()
+    monkeypatch.setitem(__import__("sys").modules, "model", ModuleType("model"))
+    monkeypatch.setattr(
+        PCVRExperiment,
+        "_resolve_schema_path",
+        lambda self, dataset_path, schema_path, checkpoint_dir: checkpoint_dir / "schema.json",
+    )
+    monkeypatch.setattr(experiment_module, "parse_seq_max_lens", lambda value: {})
+    monkeypatch.setattr(experiment_module.pcvr_data, "PCVRParquetDataset", lambda **kwargs: FakeDataset())
+    monkeypatch.setattr(experiment_module, "DataLoader", lambda dataset, batch_size, num_workers, pin_memory: [])
+    monkeypatch.setattr(experiment_module, "build_pcvr_model", lambda **kwargs: fake_model)
+    monkeypatch.setattr(experiment_module, "load_checkpoint_state_dict", lambda path, map_location=None: loaded_state_dict)
+    monkeypatch.setattr(
+        experiment_module.torch,
+        "load",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("torch.load should not be used for safetensors checkpoints")),
+    )
+
+    payload = experiment._run_prediction_loop(
+        dataset_path=tmp_path / "eval.parquet",
+        schema_path=None,
+        checkpoint_path=checkpoint_path,
+        batch_size=32,
+        num_workers=0,
+        device="cpu",
+        is_training_data=False,
+        config={"seq_max_lens": "{}"},
+    )
+
+    assert payload == {"labels": [], "probabilities": [], "records": []}
+    assert fake_model.loaded_state_dict is loaded_state_dict
+
+
 def test_evaluate_writes_score_diagnostics(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     experiment = _make_experiment(tmp_path)
     checkpoint_dir = tmp_path / "checkpoint"
     checkpoint_dir.mkdir()
-    checkpoint_path = checkpoint_dir / "model.pt"
+    checkpoint_path = checkpoint_dir / "model.safetensors"
     checkpoint_path.write_bytes(b"checkpoint")
     schema_payload = {"features": [{"name": "label"}]}
     (checkpoint_dir / "schema.json").write_text(dumps(schema_payload), encoding="utf-8")

--- a/tests/unit/test_pcvr_trainer.py
+++ b/tests/unit/test_pcvr_trainer.py
@@ -43,7 +43,7 @@ def test_train_logs_progress_when_tqdm_is_disabled(monkeypatch, tmp_path, caplog
         num_epochs=1,
         device="cpu",
         save_dir=tmp_path / "checkpoints",
-        early_stopping=EarlyStopping(tmp_path / "best" / "model.pt", patience=2),
+        early_stopping=EarlyStopping(tmp_path / "best" / "model.safetensors", patience=2),
     )
 
     losses = iter((0.5, 0.4, 0.3, 0.2))
@@ -89,7 +89,7 @@ def test_trainer_runtime_execution_wraps_train_and_predict(monkeypatch, tmp_path
         num_epochs=1,
         device="cpu",
         save_dir=tmp_path / "checkpoints",
-        early_stopping=EarlyStopping(tmp_path / "best" / "model.pt", patience=2),
+        early_stopping=EarlyStopping(tmp_path / "best" / "model.safetensors", patience=2),
         runtime_execution=RuntimeExecutionConfig(amp=True, amp_dtype="float16", compile=True),
     )
     monkeypatch.setattr(trainer, "_make_model_input", lambda batch: object())
@@ -128,7 +128,7 @@ def test_trainer_delegates_loss_to_shared_runtime(monkeypatch, tmp_path) -> None
         num_epochs=1,
         device="cpu",
         save_dir=tmp_path / "checkpoints",
-        early_stopping=EarlyStopping(tmp_path / "best" / "model.pt", patience=2),
+        early_stopping=EarlyStopping(tmp_path / "best" / "model.safetensors", patience=2),
         loss_type="FOCAL",
         focal_alpha=0.25,
         focal_gamma=1.5,
@@ -167,7 +167,7 @@ def test_trainer_accepts_orthogonal_adamw(tmp_path) -> None:
         num_epochs=1,
         device="cpu",
         save_dir=tmp_path / "checkpoints",
-        early_stopping=EarlyStopping(tmp_path / "best" / "model.pt", patience=2),
+        early_stopping=EarlyStopping(tmp_path / "best" / "model.safetensors", patience=2),
         dense_optimizer_type="orthogonal_adamw",
     )
 
@@ -184,7 +184,7 @@ def test_evaluate_accepts_bfloat16_logits(tmp_path) -> None:
         num_epochs=1,
         device="cpu",
         save_dir=tmp_path / "checkpoints",
-        early_stopping=EarlyStopping(tmp_path / "best" / "model.pt", patience=2),
+        early_stopping=EarlyStopping(tmp_path / "best" / "model.safetensors", patience=2),
     )
     logits = iter(
         (
@@ -213,7 +213,7 @@ def test_evaluate_records_score_diagnostics(tmp_path, caplog) -> None:
         num_epochs=1,
         device="cpu",
         save_dir=tmp_path / "checkpoints",
-        early_stopping=EarlyStopping(tmp_path / "best" / "model.pt", patience=2),
+        early_stopping=EarlyStopping(tmp_path / "best" / "model.safetensors", patience=2),
     )
     logits = iter(
         (

--- a/tests/unit/test_runtime_contract_matrix.py
+++ b/tests/unit/test_runtime_contract_matrix.py
@@ -17,7 +17,6 @@ from taac2026.infrastructure.checkpoints import (
     write_checkpoint_sidecars,
 )
 from taac2026.infrastructure.experiments.loader import load_experiment_package
-from taac2026.infrastructure.io.json_utils import dumps, loads
 from taac2026.infrastructure.pcvr.protocol import (
     batch_to_model_input,
     build_feature_specs,
@@ -28,6 +27,7 @@ from taac2026.infrastructure.pcvr.protocol import (
     resolve_ns_groups_path,
     resolve_schema_path,
 )
+from taac2026.infrastructure.io.json_utils import dumps, loads
 from tests.unit._pcvr_experiment_matrix import ExperimentCase, REPO_ROOT, discover_pcvr_experiment_cases, load_model_module
 
 
@@ -479,11 +479,11 @@ def test_build_pcvr_model_forwards_constructor_contract(
         (Path("global_step0"), 0),
         (Path("global_step12.layer=2"), 12),
         (Path("global_step12.layer=2.best_model"), 12),
-        (Path("global_step3.head=4") / "model.pt", 3),
+        (Path("global_step3.head=4") / "model.safetensors", 3),
         (Path("global_step0007"), 7),
         (Path("global_step9.hidden=64.extra_token"), 9),
         (Path("best_model"), -1),
-        (Path("invalid_parent") / "model.pt", -1),
+        (Path("invalid_parent") / "model.safetensors", -1),
     ],
 )
 def test_checkpoint_step_cases(path_value: Path, expected: int) -> None:
@@ -538,9 +538,10 @@ def test_build_checkpoint_dir_name_rejects_negative_global_step() -> None:
     [
         "explicit_file",
         "explicit_dir",
+        "legacy_pt_file",
         "best_model",
         "latest_step",
-        "direct_model",
+        "direct_checkpoint",
         "missing",
     ],
 )
@@ -549,7 +550,7 @@ def test_resolve_checkpoint_path_cases(tmp_path: Path, scenario: str) -> None:
     run_dir.mkdir()
 
     if scenario == "explicit_file":
-        candidate = tmp_path / "manual.pt"
+        candidate = tmp_path / "manual.safetensors"
         candidate.write_text("manual", encoding="utf-8")
         assert resolve_checkpoint_path(run_dir, candidate) == candidate.resolve()
         return
@@ -557,9 +558,16 @@ def test_resolve_checkpoint_path_cases(tmp_path: Path, scenario: str) -> None:
     if scenario == "explicit_dir":
         candidate_dir = tmp_path / "manual_dir"
         candidate_dir.mkdir()
-        model_path = candidate_dir / "model.pt"
+        model_path = candidate_dir / "model.safetensors"
         model_path.write_text("manual", encoding="utf-8")
         assert resolve_checkpoint_path(run_dir, candidate_dir) == model_path.resolve()
+        return
+
+    if scenario == "legacy_pt_file":
+        legacy_path = tmp_path / "manual.pt"
+        legacy_path.write_text("legacy", encoding="utf-8")
+        with pytest.raises(ValueError, match=r"unsupported checkpoint format"):
+            resolve_checkpoint_path(run_dir, legacy_path)
         return
 
     if scenario == "best_model":
@@ -567,9 +575,9 @@ def test_resolve_checkpoint_path_cases(tmp_path: Path, scenario: str) -> None:
         newer = run_dir / "global_step2.best_model"
         older.mkdir()
         newer.mkdir()
-        (older / "model.pt").write_text("old", encoding="utf-8")
-        (newer / "model.pt").write_text("new", encoding="utf-8")
-        assert resolve_checkpoint_path(run_dir) == (newer / "model.pt").resolve()
+        (older / "model.safetensors").write_text("old", encoding="utf-8")
+        (newer / "model.safetensors").write_text("new", encoding="utf-8")
+        assert resolve_checkpoint_path(run_dir) == (newer / "model.safetensors").resolve()
         return
 
     if scenario == "latest_step":
@@ -577,18 +585,18 @@ def test_resolve_checkpoint_path_cases(tmp_path: Path, scenario: str) -> None:
         newer = run_dir / "global_step3.layer=2"
         older.mkdir()
         newer.mkdir()
-        (older / "model.pt").write_text("old", encoding="utf-8")
-        (newer / "model.pt").write_text("new", encoding="utf-8")
-        assert resolve_checkpoint_path(run_dir) == (newer / "model.pt").resolve()
+        (older / "model.safetensors").write_text("old", encoding="utf-8")
+        (newer / "model.safetensors").write_text("new", encoding="utf-8")
+        assert resolve_checkpoint_path(run_dir) == (newer / "model.safetensors").resolve()
         return
 
-    if scenario == "direct_model":
-        direct_model = run_dir / "model.pt"
+    if scenario == "direct_checkpoint":
+        direct_model = run_dir / "model.safetensors"
         direct_model.write_text("direct", encoding="utf-8")
         assert resolve_checkpoint_path(run_dir) == direct_model.resolve()
         return
 
-    with pytest.raises(FileNotFoundError, match=r"no model\.pt checkpoint"):
+    with pytest.raises(FileNotFoundError, match=r"no model\.safetensors checkpoint"):
         resolve_checkpoint_path(run_dir)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1536,6 +1536,28 @@ wheels = [
 ]
 
 [[package]]
+name = "safetensors"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/9c/6e74567782559a63bd040a236edca26fd71bc7ba88de2ef35d75df3bca5e/safetensors-0.7.0.tar.gz", hash = "sha256:07663963b67e8bd9f0b8ad15bb9163606cd27cc5a1b96235a50d8369803b96b0", size = 200878, upload-time = "2025-11-19T15:18:43.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/06/578ffed52c2296f93d7fd2d844cabfa92be51a587c38c8afbb8ae449ca89/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e07d91d0c92a31200f25351f4acb2bc6aff7f48094e13ebb1d0fb995b54b6542", size = 491748, upload-time = "2025-11-19T15:18:09.79Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/33/1debbbb70e4791dde185edb9413d1fe01619255abb64b300157d7f15dddd/safetensors-0.7.0-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8469155f4cb518bafb4acf4865e8bb9d6804110d2d9bdcaa78564b9fd841e104", size = 503881, upload-time = "2025-11-19T15:18:16.145Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/1c/40c2ca924d60792c3be509833df711b553c60effbd91da6f5284a83f7122/safetensors-0.7.0-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:54bef08bf00a2bff599982f6b08e8770e09cc012d7bba00783fc7ea38f1fb37d", size = 623463, upload-time = "2025-11-19T15:18:21.11Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3a/13784a9364bd43b0d61eef4bea2845039bc2030458b16594a1bd787ae26e/safetensors-0.7.0-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:42cb091236206bb2016d245c377ed383aa7f78691748f3bb6ee1bfa51ae2ce6a", size = 532855, upload-time = "2025-11-19T15:18:25.719Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac7252938f0696ddea46f5e855dd3138444e82236e3be475f54929f0c510d48", size = 507152, upload-time = "2025-11-19T15:18:33.023Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a8/4b45e4e059270d17af60359713ffd83f97900d45a6afa73aaa0d737d48b6/safetensors-0.7.0-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1d060c70284127fa805085d8f10fbd0962792aed71879d00864acda69dbab981", size = 541856, upload-time = "2025-11-19T15:18:31.075Z" },
+    { url = "https://files.pythonhosted.org/packages/06/87/d26d8407c44175d8ae164a95b5a62707fcc445f3c0c56108e37d98070a3d/safetensors-0.7.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:cdab83a366799fa730f90a4ebb563e494f28e9e92c4819e556152ad55e43591b", size = 674060, upload-time = "2025-11-19T15:18:37.211Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f5/57644a2ff08dc6325816ba7217e5095f17269dada2554b658442c66aed51/safetensors-0.7.0-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:672132907fcad9f2aedcb705b2d7b3b93354a2aec1b2f706c4db852abe338f85", size = 771715, upload-time = "2025-11-19T15:18:38.689Z" },
+    { url = "https://files.pythonhosted.org/packages/86/31/17883e13a814bd278ae6e266b13282a01049b0c81341da7fd0e3e71a80a3/safetensors-0.7.0-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:5d72abdb8a4d56d4020713724ba81dac065fedb7f3667151c4a637f1d3fb26c0", size = 714377, upload-time = "2025-11-19T15:18:40.162Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d8/0c8a7dc9b41dcac53c4cbf9df2b9c83e0e0097203de8b37a712b345c0be5/safetensors-0.7.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b0f6d66c1c538d5a94a73aa9ddca8ccc4227e6c9ff555322ea40bdd142391dd4", size = 677368, upload-time = "2025-11-19T15:18:41.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6a/4d08d89a6fcbe905c5ae68b8b34f0791850882fc19782d0d02c65abbdf3b/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f4729811a6640d019a4b7ba8638ee2fd21fa5ca8c7e7bdf0fed62068fcaac737", size = 492430, upload-time = "2025-11-19T15:18:11.884Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/29/59ed8152b30f72c42d00d241e58eaca558ae9dbfa5695206e2e0f54c7063/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12f49080303fa6bb424b362149a12949dfbbf1e06811a88f2307276b0c131afd", size = 503977, upload-time = "2025-11-19T15:18:17.523Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0b/4811bfec67fa260e791369b16dab105e4bae82686120554cc484064e22b4/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0071bffba4150c2f46cae1432d31995d77acfd9f8db598b5d1a2ce67e8440ad2", size = 623890, upload-time = "2025-11-19T15:18:22.666Z" },
+    { url = "https://files.pythonhosted.org/packages/58/5b/632a58724221ef03d78ab65062e82a1010e1bef8e8e0b9d7c6d7b8044841/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:473b32699f4200e69801bf5abf93f1a4ecd432a70984df164fc22ccf39c4a6f3", size = 531885, upload-time = "2025-11-19T15:18:27.146Z" },
+]
+
+[[package]]
 name = "scikit-learn"
 version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1678,6 +1700,7 @@ dependencies = [
     { name = "pytest", marker = "sys_platform == 'linux'" },
     { name = "pytest-benchmark", marker = "sys_platform == 'linux'" },
     { name = "rich", marker = "sys_platform == 'linux'" },
+    { name = "safetensors", marker = "sys_platform == 'linux'" },
     { name = "scikit-learn", marker = "sys_platform == 'linux'" },
     { name = "tensorboard", marker = "sys_platform == 'linux'" },
     { name = "tomli", marker = "sys_platform == 'linux'" },
@@ -1704,6 +1727,7 @@ requires-dist = [
     { name = "pytest", specifier = "==9.0.3" },
     { name = "pytest-benchmark", specifier = "==5.2.3" },
     { name = "rich", specifier = "==14.3.3" },
+    { name = "safetensors", specifier = "==0.7.0" },
     { name = "scikit-learn", specifier = "==1.7.2" },
     { name = "tensorboard", specifier = "==2.19.0" },
     { name = "tomli", specifier = "==2.4.0" },


### PR DESCRIPTION
## 变更说明
- 将训练侧 checkpoint 保存统一迁移为 `model.safetensors`，并通过共享 helper 处理保存、发现与加载逻辑
- 将 PCVR 推理/评估入口改为通过 checkpoint helper 加载状态字典，避免继续使用 `torch.load` 读取 safetensors 文件
- 更新与 checkpoint 命名、解析、运行时加载相关的单元测试，并同步 README / 架构文档中的输出文件名说明
- 在依赖中加入 `safetensors` 并更新锁文件

## 验证
- `uv run pytest tests/unit/test_pcvr_trainer.py tests/unit/test_evaluation_cli.py tests/unit/test_pcvr_infer_runtime.py tests/unit/test_checkpoint_and_loader.py tests/unit/test_runtime_contract_matrix.py -q`

Closes #68