### PR TITLE
Add observed schema sidecars and separate dev extras

### DIFF
--- a/.agents/skills/taac-competition-environment/SKILL.md
+++ b/.agents/skills/taac-competition-environment/SKILL.md
@@ -39,6 +39,7 @@ git lfs install
 git lfs pull
 uv python install 3.10.20
 uv sync --locked --extra cuda126
+uv sync --locked --extra dev --extra cuda126  # when running tests, lint, or local docs
 ```
 
 For local training or validation, use the only CUDA profile currently supported by the project:
@@ -61,7 +62,7 @@ bash run.sh package --experiment config/interformer --output-dir /tmp/interforme
 Local defaults:
 
 - All local commands use CUDA profile `cuda126`; setting `TAAC_CUDA_PROFILE` or `--cuda-profile` to any other value is treated as an error.
-- Training, evaluation, inference, and packaging commands all reuse the same `cuda126` environment; pytest, hypothesis, and benchmark tooling are part of the default dependencies and should be run with `uv run pytest`.
+- Training, evaluation, inference, and packaging commands all reuse the same `cuda126` environment; pytest, hypothesis, benchmark tooling, coverage helpers, Ruff, and Zensical live in the `dev` extra and should be installed with `uv sync --locked --extra dev --extra cuda126` when needed.
 - `TAAC_SKIP_UV_SYNC=1` skips automatic `uv sync` when the environment is already prepared.
 - `TAAC_INSTALL_UV=0` prevents `run.sh` from trying to install `uv` if it is missing.
 
@@ -71,9 +72,8 @@ The project requires Python `>=3.10,<3.14`.
 
 Important extras:
 
+- `dev`: Ruff, pytest, hypothesis, benchmark tooling, coverage helpers, and Zensical for local testing and docs work.
 - `cuda126`: CUDA 12.6 PyTorch, FBGEMM, and TorchRec runtime for the repository.
-
-Default dependencies already include pytest, hypothesis, and benchmark tooling.
 
 Do not point `uv` at an alternate package index unless you are intentionally updating dependency resolution. The lockfile is expected to resolve against the indexes declared in `pyproject.toml`.
 
@@ -132,6 +132,7 @@ Dependency responsibility online:
 - Prefer the platform or image-provided CUDA, PyTorch, FBGEMM, and TorchRec stack.
 - Use Conda for the base Python/CUDA/PyTorch environment if the platform allows custom images or startup commands.
 - Use pip inside that Conda environment only for missing pure-Python packages that are not already available.
+- Packaged `run.sh` and `infer.py` default to `pip install .` and therefore skip the repository `dev` extra; use `TAAC_BUNDLE_PIP_EXTRAS` only when you intentionally need an extra inside bundle mode.
 - Do not call `uv sync` or require `uv.lock` online; `uv.lock` remains a local repository artifact for provenance and reproducibility and is not packaged into online bundles.
 
 If the platform image allows a pre-run dependency step, use the active Conda Python:
@@ -164,6 +165,7 @@ Important runtime variables:
 - `TAAC_BUNDLE_WORKDIR`: directory where `code_package.zip` is extracted.
 - `TAAC_CODE_PACKAGE`: non-default path to `code_package.zip`.
 - `TAAC_FORCE_EXTRACT=1`: force re-extraction of the zip.
+- `TAAC_BUNDLE_PIP_EXTRAS`: optional extras to install in bundle mode; default is empty so packaged train/infer skip `dev`.
 - `TAAC_PYTHON`: explicit Python interpreter, often the active Conda interpreter.
 - `TAAC_RUNNER=python`: force online no-uv execution.
 
@@ -184,14 +186,15 @@ python -m taac2026.application.training.cli --experiment <manifest experiment> .
 Use this lifecycle for competition work:
 
 1. Develop locally with `uv sync --locked --extra cuda126`.
-2. Add or modify an experiment package under `config/<name>`.
-3. Run focused unit tests locally with `uv run pytest tests/unit -q`.
-4. For training experiments, keep the same `cuda126` environment and train through `bash run.sh train --experiment config/<name>`.
-5. Build the online bundle with `bash run.sh package --experiment config/<name> --force`.
-6. Inspect `code_package.zip` when changing packaging logic; confirm it contains the selected experiment package and required assets such as `ns_groups.json`.
-7. Upload only `run.sh` and `code_package.zip` to the online platform.
-8. Run online in the platform Conda/Python environment with `TAAC_RUNNER=python` and dataset/output environment variables.
-9. Collect checkpoints, logs, tensorboard events, predictions, and sidecars from the platform output directory.
+2. Install local dev tooling with `uv sync --locked --extra dev --extra cuda126` when you need pytest, Ruff, or docs preview.
+3. Add or modify an experiment package under `config/<name>`.
+4. Run focused unit tests locally with `uv run pytest tests/unit -q`.
+5. For training experiments, keep the same `cuda126` environment and train through `bash run.sh train --experiment config/<name>`.
+6. Build the online bundle with `bash run.sh package --experiment config/<name> --force`.
+7. Inspect `code_package.zip` when changing packaging logic; confirm it contains the selected experiment package and required assets such as `ns_groups.json`.
+8. Upload only `run.sh` and `code_package.zip` to the online platform.
+9. Run online in the platform Conda/Python environment with `TAAC_RUNNER=python` and dataset/output environment variables.
+10. Collect checkpoints, logs, tensorboard events, predictions, and sidecars from the platform output directory.
 
 ## Validation Commands
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,10 +76,10 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: 同步项目环境
-        run: uv sync --locked --extra cuda126 --no-install-package torchrec --no-install-package fbgemm-gpu
+        run: uv sync --locked --extra dev
 
       - name: 运行带有覆盖率的单元测试
-        run: uv run --with coverage coverage run --data-file=.coverage.cpu -m pytest -m unit -v
+        run: uv run --with torch==2.7.1 --with coverage coverage run --data-file=.coverage.cpu -m pytest -m unit -v
 
       - name: 上传 CPU 覆盖率数据
         if: always() && matrix.python-version == env.CI_CANONICAL_PYTHON_VERSION

--- a/README.md
+++ b/README.md
@@ -68,7 +68,12 @@
 
 ```bash
 uv python install 3.10.20
+
+# 仅训练/评估
 uv sync --locked --extra cuda126
+
+# 需要测试、lint 或本地文档站时
+uv sync --locked --extra dev --extra cuda126
 
 # 训练baseline
 bash run.sh train --experiment config/baseline \
@@ -88,7 +93,7 @@ uv run taac-package-train --experiment config/baseline
 # 生成线上推理上传文件
 uv run taac-package-infer --experiment config/baseline
 
-# 跑完整训练栈回归
+# 跑完整训练栈回归（需 `--extra dev`）
 uv run pytest tests -q
 ```
 

--- a/docs/analysis/feature-schema.md
+++ b/docs/analysis/feature-schema.md
@@ -4,24 +4,47 @@ icon: lucide/table-properties
 
 # 特征 Schema 参考
 
-本项目涉及多份特征 schema，结构相同但基数不同。Schema 随数据集规模变化——样本量越大，观测到的唯一值越多，基数越接近真实分布。
+本项目现在需要区分两类 schema：
+
+- 声明式 schema：原始 `schema.json`，描述列布局、特征 FID、词表大小上界和 multi-hot 维度。训练、评估、推理加载数据时首先读取这一份。
+- 观测 schema：按真实 parquet 内容统计得到的 sidecar，和 `schema.json` 形状一致，但基数与实际 multi-hot 维度来自当前数据切片。
+
+Schema 会随数据集规模变化而变化。样本量越大，观测到的唯一值越多，基数越接近真实分布；因此 Train / Eval 不能再直接抄运行日志里的 `Loaded PCVR schema`，必须使用 split-specific observed schema sidecar。
+
+> [!IMPORTANT]
+> 当前运行日志里的 `PCVR train schema payload` / `PCVR valid schema payload` 是压缩成单行 JSON 的声明式 `schema.json`，便于日志检索，但它们不是 Train / Eval 独立统计结果。
+>
+> 当前实现中，真正用于回填 Train / Eval 列的文件是：
+> - 训练：`train_split_observed_schema.json`、`valid_split_observed_schema.json`
+> - 评估：`evaluation_observed_schema.json`
 
 ## 数据集与 Schema 对应关系
 
-| Schema    | 来源                               | 样本量               | 用途                                      | 状态   |
-| --------- | ---------------------------------- | -------------------- | ----------------------------------------- | ------ |
-| **Infer** |                                    | 31 万+（完整训练集） | `taac-evaluate infer` 线上打分，无 label  | 已有   |
-| **Eval**  |                                    |                      | `taac-evaluate single` 本地验证，有 label | 待补充 |
-| **Demo**  | `data/sample_1000_raw/schema.json` | 1000                 | 本地开发、单元测试                        | 已有   |
-| **Train** |                                    |                      | 训练时内部验证（Row Group split）         | 待补充 |
+| Schema    | 来源                                                                            | 样本量                                         | 用途                                      | 状态               |
+| --------- | ------------------------------------------------------------------------------- | ---------------------------------------------- | ----------------------------------------- | ------------------ |
+| **Infer** | 数据集或 checkpoint 侧车 `schema.json`（声明式）                                | 全量数据集；当前 AMS 日志示例总计 1,010,000 行 | `taac-evaluate infer` 线上打分，无 label  | 已有               |
+| **Eval**  | `evaluation_observed_schema.json`（观测）                                       | 当前 AMS 日志示例 102,619 行 / 100 Row Groups  | `taac-evaluate single` 本地验证，有 label | 已实现，待回填表格 |
+| **Demo**  | `data/sample_1000_raw/schema.json`                                              | 1000                                           | 本地开发、单元测试                        | 已有               |
+| **Train** | `train_split_observed_schema.json` / `valid_split_observed_schema.json`（观测） | 当前 AMS 日志示例 907,381 / 102,619 行         | 训练时内部验证（Row Group split）         | 已实现，待回填表格 |
+
+### 当前实现约定
+
+- `taac-train` 训练结束后会返回 `observed_schema_paths.train_split` 和 `observed_schema_paths.valid_split`。
+- `taac-evaluate single` 会在 `evaluation.json` 中返回 `observed_schema_paths.eval`，对应 `evaluation_observed_schema.json`。
+- `taac-evaluate infer` 当前仍以声明式 `schema.json` 为准，不额外生成 infer observed schema sidecar。
+- 当前 AMS 训练日志示例的 Row Group 切分为 `900 train / 100 valid`，对应 `907,381 train rows / 102,619 valid rows`。
 
 ### 流程说明
 
 ```
-训练时:  train_loader (前90% Row Groups) ──► trainer.train()
-         valid_loader (后10% Row Groups) ──► trainer.evaluate()  → AUC / early stopping
+训练时:  schema.json (声明式) ──► train_loader (前90% Row Groups) ──► trainer.train()
+                               └► valid_loader (后10% Row Groups) ──► trainer.evaluate()  → AUC / early stopping
+                               └► train_split_observed_schema.json / valid_split_observed_schema.json
 
-评估时:  taac-evaluate single  ──► experiment.evaluate()  → evaluation.json (AUC + CI)
+评估时:  taac-evaluate single  ──► experiment.evaluate()
+                               └► evaluation.json (AUC + CI)
+                               └► evaluation_observed_schema.json
+
 打分时:  taac-evaluate infer   ──► experiment.infer()     → predictions.json (user_id: score)
 ```
 
@@ -37,11 +60,13 @@ icon: lucide/table-properties
 
 稠密特征以 `[fid, dim]` 二元组定义，序列特征以 `[fid, cardinality]` 二元组定义。
 
+声明式 schema 和观测 schema 共享同一形状，因此 Train / Eval sidecar 可以直接按本文表格结构回填。
+
 ## 用户整数特征 (`user_int`)
 
 共 46 个特征。
 
-<div class="echarts" data-src="../assets/figures/schema/user_int_cardinality.echarts.json"></div>
+下表直接给出 `user_int` 在 Infer / Eval / Demo / Train 之间的基数对比，重点关注高基数用户 ID、用户分群以及多值交叉特征的覆盖差异。
 
 | FID | Infer 基数 | Eval 基数 | Demo 基数 | Train 基数 | Infer Multi-Hot | Eval Multi-Hot | Demo Multi-Hot | Train Multi-Hot | 说明           |
 | --- | ---------- | --------- | --------- | ---------- | --------------- | -------------- | -------------- | --------------- | -------------- |
@@ -91,14 +116,13 @@ icon: lucide/table-properties
 | 107 | 4          |           | 3         |            | 1               |                | 1              |                 |                |
 | 108 | 8          |           | 8         |            | 1               |                | 1              |                 |                |
 | 109 | 8          |           | 8         |            | 1               |                | 1              |                 |                |
-
-<div class="echarts" data-src="../assets/figures/schema/user_int_multihot.echarts.json"></div>
+上表同时覆盖 `user_int` 的 multi-hot 维度变化，可直接对比完整数据、开发样本和后续待补齐的 split 观测结果。
 
 ## 物品整数特征 (`item_int`)
 
 共 14 个特征。
 
-<div class="echarts" data-src="../assets/figures/schema/item_int_cardinality.echarts.json"></div>
+下表直接展示 `item_int` 的基数与 multi-hot 差异，尤其适合观察物品 ID、内容特征和交叉特征在不同数据规模下的离散程度。
 
 | FID | Infer 基数 | Eval 基数 | Demo 基数 | Train 基数 | Infer Multi-Hot | Eval Multi-Hot | Demo Multi-Hot | Train Multi-Hot | 说明              |
 | --- | ---------- | --------- | --------- | ---------- | --------------- | -------------- | -------------- | --------------- | ----------------- |
@@ -121,7 +145,7 @@ icon: lucide/table-properties
 
 共 10 个特征。
 
-<div class="echarts" data-src="../assets/figures/schema/user_dense_dim.echarts.json"></div>
+下表直接比较 `user_dense` 的维度变化，用于判断 embedding 向量、统计特征和序列聚合特征在不同 schema 下是否保持一致。
 
 | FID | Infer 维度 | Eval 维度 | Demo 维度 | Train 维度 | 说明                  |
 | --- | ---------- | --------- | --------- | ---------- | --------------------- |
@@ -140,7 +164,7 @@ icon: lucide/table-properties
 
 共 4 条行为序列，支持跨域兴趣建模。
 
-<div class="echarts" data-src="../assets/figures/schema/seq_cardinality.echarts.json"></div>
+下文按域分别列出序列特征基数，便于直接比较各行为域在完整数据、开发样本和后续观测 sidecar 之间的覆盖范围与时间戳统计差异。
 
 ### seq_a — 域 A 序列
 
@@ -225,6 +249,8 @@ icon: lucide/table-properties
 
 ## Infer vs Demo 差异总结
 
+- 当前日志里的 `PCVR train schema payload` / `PCVR valid schema payload` 已改为单行打印，便于平台日志检索；它们表示声明式 schema，不表示 Train / Eval 的 observed schema。
+- Train / Eval 列后续应从 `train_split_observed_schema.json`、`valid_split_observed_schema.json`、`evaluation_observed_schema.json` 回填，而不是从日志里的单行 payload 复制。
 - **multi-hot 维度**差异显著：Infer 来自完整数据集，multi-hot 更大（如 FID 65: 111 vs 49）
 - **物品 ID 基数**：Demo 32506 > Infer 21528，Demo 样本的物品分布更分散
 - **时间戳 FID**（39/67/27/26）：Demo 有实际值（如 1772725488），Infer 为 0（线上 schema 未统计时间戳范围）

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,7 +18,7 @@ icon: lucide/rocket
     ```bash
     git clone https://github.com/Puiching-Memory/TAAC_2026.git
     cd TAAC_2026
-    uv sync --extra dev --extra pcvr
+    uv sync --extra dev --extra cuda126
     ```
 
 === "pip"
@@ -26,13 +26,13 @@ icon: lucide/rocket
     ```bash
     git clone https://github.com/Puiching-Memory/TAAC_2026.git
     cd TAAC_2026
-    pip install -e ".[dev,pcvr]"
+    pip install -e ".[dev,cuda126]"
     ```
 
 依赖说明：
 
-- `--extra dev`：Ruff、Pytest、覆盖率工具
-- `--extra pcvr`：PyTorch、TorchRec、FBGEMM
+- `--extra dev`：Ruff、Pytest、Hypothesis、Benchmark、覆盖率插件、Zensical
+- `--extra cuda126`：PyTorch、TorchRec、FBGEMM
 
 ## 准备数据
 
@@ -91,12 +91,14 @@ uv run taac-package-train \
 ## 测试
 
 ```bash
+# 已执行 uv sync --extra dev --extra cuda126
 uv run pytest tests/unit -v
 ```
 
 ## 本地文档站
 
 ```bash
+# 已执行 uv sync --extra dev
 uv run zensical serve
 ```
 

--- a/docs/guide/online-training-bundle.md
+++ b/docs/guide/online-training-bundle.md
@@ -123,10 +123,16 @@ Bundle 格式与官方 Baseline 兼容：
 平台使用 `uv` 安装依赖：
 
 ```bash
-uv sync --extra pcvr
+uv sync --extra cuda126
 ```
 
 确保 `pyproject.toml` 中的依赖在平台上可安装。如果使用自定义依赖，需要在 Bundle 中包含。
+
+打包后的 `train` 和 `infer` 默认只安装 runtime 依赖，相当于执行 `pip install .`，不会自动安装 `dev` extra。只有在确实需要额外 extra 时，才显式设置：
+
+```bash
+export TAAC_BUNDLE_PIP_EXTRAS="dev"
+```
 
 ## 检查 Bundle
 
@@ -151,7 +157,7 @@ python outputs/bundle/infer.py
 ## 依赖原则
 
 - 框架依赖通过 `pyproject.toml` 声明，不要手动 pip install
-- 使用 `--extra pcvr` 安装 PyTorch 相关依赖
+- 使用 `--extra cuda126` 安装 PyTorch 相关依赖
 - 避免依赖本地编译的 C++ 扩展
 
 ## 常见问题

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -4,6 +4,12 @@ icon: lucide/clipboard-list
 
 # 测试
 
+## 前置条件
+
+```bash
+uv sync --extra dev --extra cuda126
+```
+
 ## 常用命令
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ icon: lucide/house
 
 ```bash
 # 安装
-uv sync --extra dev --extra pcvr
+uv sync --extra dev --extra cuda126
 
 # 训练
 uv run taac-train --experiment config/baseline \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,13 +13,10 @@ classifiers = [
 ]
 dependencies = [
 	"datasets==2.14.7",
-	"hypothesis==6.151.12",
 	"matplotlib==3.10.8",
 	"numpy==2.2.5",
 	"orjson==3.11.8",
 	"pyarrow==23.0.1",
-	"pytest==9.0.3",
-	"pytest-benchmark==5.2.3",
 	"rich==14.3.3",
 	"safetensors==0.7.0",
 	"scikit-learn==1.7.2",
@@ -30,6 +27,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+dev = [
+	"hypothesis==6.151.12",
+	"pytest==9.0.3",
+	"pytest-benchmark==5.2.3",
+	"pytest-cov==7.1.0",
+	"ruff==0.15.12",
+	"zensical==0.0.38",
+]
 cuda126 = [
 	"torch==2.7.1+cu126",
 	"fbgemm-gpu==1.2.0+cu126",

--- a/run.sh
+++ b/run.sh
@@ -151,14 +151,18 @@ ensure_project_pip_dependencies() {
 	fi
 
 	ensure_python
-	TAAC_DEFAULT_PIP_INDEX_URL="${TENCENT_PYPI_INDEX_URL}" "${PYTHON_BIN}" - <<'PY'
+	TAAC_DEFAULT_PIP_INDEX_URL="${TENCENT_PYPI_INDEX_URL}" \
+	TAAC_PIP_EXTRAS_ENV_NAME="$([[ "${BUNDLE_MODE}" == "1" ]] && printf '%s' "TAAC_BUNDLE_PIP_EXTRAS" || printf '%s' "TAAC_PIP_EXTRAS")" \
+	"${PYTHON_BIN}" - <<'PY'
 import os
 import shlex
 import subprocess
 import sys
 
 extra_args = shlex.split(os.environ.get("TAAC_PIP_EXTRA_ARGS", ""))
-extras = shlex.split(os.environ.get("TAAC_PIP_EXTRAS", ""))
+extras = shlex.split(
+    os.environ.get(os.environ.get("TAAC_PIP_EXTRAS_ENV_NAME", "TAAC_PIP_EXTRAS"), "")
+)
 target = "."
 if extras:
     target = f".[{','.join(extras)}]"

--- a/src/taac2026/application/maintenance/package_inference.py
+++ b/src/taac2026/application/maintenance/package_inference.py
@@ -90,7 +90,7 @@ def _should_install_project_pip_dependencies() -> bool:
 def _install_project_pip_dependencies(project_dir: Path) -> None:
     if not _should_install_project_pip_dependencies():
         return
-    extras = _split_env_words("TAAC_PIP_EXTRAS")
+    extras = _split_env_words("TAAC_BUNDLE_PIP_EXTRAS")
     target = "."
     if extras:
         target = f".[{','.join(extras)}]"
@@ -158,6 +158,7 @@ def _format_bundle_summary(result: BundleResult) -> str:
                 f"  dataset: {runtime_env.get('dataset_path', '<unknown>')}",
                 f"  result: {runtime_env.get('result_path', '<unknown>')}",
                 f"  schema: {runtime_env.get('schema_path', '<unknown>')}",
+                f"  pip extras: {runtime_env.get('pip_extras', '<unknown>')}",
             ]
         )
     lines.append("Upload the two files above: infer.py and code_package.zip")
@@ -229,6 +230,7 @@ def build_inference_bundle(
             "dataset_path": "EVAL_DATA_PATH",
             "result_path": "EVAL_RESULT_PATH",
             "schema_path": "TAAC_SCHEMA_PATH",
+            "pip_extras": "TAAC_BUNDLE_PIP_EXTRAS (optional; defaults to runtime-only install with no dev extra)",
         },
     }
     if force:

--- a/src/taac2026/application/maintenance/package_training.py
+++ b/src/taac2026/application/maintenance/package_training.py
@@ -50,6 +50,7 @@ def _format_bundle_summary(result: BundleResult) -> str:
                 f"  schema: {runtime_env.get('schema_path', '<unknown>')}",
                 f"  output: {runtime_env.get('checkpoint_path', '<unknown>')}",
                 f"  cuda profile: {runtime_env.get('cuda_profile', '<unknown>')}",
+                f"  pip extras: {runtime_env.get('pip_extras', '<unknown>')}",
             ]
         )
     lines.append("Upload the two files above: run.sh and code_package.zip")
@@ -154,6 +155,7 @@ def build_training_bundle(
             "schema_path": "TAAC_SCHEMA_PATH",
             "checkpoint_path": "TAAC_OUTPUT_DIR or TRAIN_CKPT_PATH",
             "cuda_profile": "TAAC_CUDA_PROFILE",
+            "pip_extras": "TAAC_BUNDLE_PIP_EXTRAS (optional; defaults to runtime-only install with no dev extra)",
         },
     }
     if force:

--- a/src/taac2026/infrastructure/pcvr/data.py
+++ b/src/taac2026/infrastructure/pcvr/data.py
@@ -28,7 +28,7 @@ import torch.multiprocessing
 from numpy.typing import NDArray
 from torch.utils.data import IterableDataset, DataLoader
 
-from taac2026.infrastructure.io.json_utils import read_path
+from taac2026.infrastructure.io.json_utils import dumps, read_path
 from taac2026.infrastructure.pcvr.config import PCVRDataPipelineConfig
 from taac2026.infrastructure.pcvr.data_pipeline import (
     PCVRBatchTransform,
@@ -109,6 +109,8 @@ class FeatureSchema:
 # Use filesystem-based tensor sharing (instead of /dev/shm) to avoid running
 # out of shared memory when many DataLoader workers are active.
 torch.multiprocessing.set_sharing_strategy("file_system")
+
+DEFAULT_PCVR_OBSERVED_SCHEMA_BATCH_SIZE = 1024
 
 # Time-delta bucket boundaries (64 edges -> 65 buckets: 0=padding, 1..64).
 BUCKET_BOUNDARIES = np.array(
@@ -221,6 +223,241 @@ class PCVRRowGroupSplitPlan:
         )
 
 
+class _ExactPositiveCardinalityCounter:
+    def __init__(self, max_value_hint: int) -> None:
+        self.max_value_hint = max(0, int(max_value_hint))
+        self._bitset = bytearray((self.max_value_hint // 8) + 1) if self.max_value_hint > 0 else bytearray()
+        self._overflow_values: set[int] = set()
+        self.count = 0
+
+    def add_values(self, values: NDArray[np.int64]) -> None:
+        if values.size == 0:
+            return
+        positive_values = values[values > 0]
+        if positive_values.size == 0:
+            return
+        for raw_value in np.unique(positive_values).tolist():
+            value = int(raw_value)
+            if 0 < value <= self.max_value_hint:
+                byte_index = value >> 3
+                bit_mask = 1 << (value & 7)
+                if self._bitset[byte_index] & bit_mask:
+                    continue
+                self._bitset[byte_index] |= bit_mask
+                self.count += 1
+                continue
+            if value not in self._overflow_values:
+                self._overflow_values.add(value)
+                self.count += 1
+
+
+def _is_list_like_arrow_type(data_type: pa.DataType) -> bool:
+    return pa.types.is_list(data_type) or pa.types.is_large_list(data_type)
+
+
+def _list_lengths(array: pa.Array) -> NDArray[np.int64]:
+    offsets = array.offsets.to_numpy().astype(np.int64, copy=False)
+    return np.diff(offsets)
+
+
+def _scalar_positive_values(array: pa.Array) -> NDArray[np.int64]:
+    return array.fill_null(0).to_numpy(zero_copy_only=False).astype(np.int64, copy=False)
+
+
+def _list_positive_values(array: pa.Array) -> NDArray[np.int64]:
+    return array.values.to_numpy(zero_copy_only=False).astype(np.int64, copy=False)
+
+
+def build_pcvr_observed_schema_report(
+    data_dir: str | Path,
+    schema_path: str | Path,
+    *,
+    row_group_range: tuple[int, int] | None = None,
+    batch_size: int = DEFAULT_PCVR_OBSERVED_SCHEMA_BATCH_SIZE,
+    dataset_role: str = "dataset",
+) -> dict[str, Any]:
+    resolved_dataset_path = Path(data_dir).expanduser().resolve()
+    resolved_schema_path = Path(schema_path).expanduser().resolve()
+    raw_schema = read_path(resolved_schema_path)
+    rg_info = collect_pcvr_row_groups(resolved_dataset_path)
+    total_row_groups = len(rg_info)
+
+    if row_group_range is None:
+        start_index, end_index = 0, total_row_groups
+    else:
+        start_index, end_index = row_group_range
+        if start_index < 0 or end_index > total_row_groups or start_index >= end_index:
+            raise ValueError(
+                f"invalid row_group_range={row_group_range}; available row groups: 0..{total_row_groups}"
+            )
+
+    selected_row_groups = rg_info[start_index:end_index]
+    if not selected_row_groups:
+        raise ValueError("at least one Row Group is required to build observed schema report")
+
+    user_int_specs = [
+        {
+            "fid": int(fid),
+            "column": f"user_int_feats_{fid}",
+            "declared_dim": int(dim),
+            "observed_dim": 1 if int(dim) == 1 else 0,
+            "counter": _ExactPositiveCardinalityCounter(int(cardinality)),
+        }
+        for fid, cardinality, dim in raw_schema["user_int"]
+    ]
+    item_int_specs = [
+        {
+            "fid": int(fid),
+            "column": f"item_int_feats_{fid}",
+            "declared_dim": int(dim),
+            "observed_dim": 1 if int(dim) == 1 else 0,
+            "counter": _ExactPositiveCardinalityCounter(int(cardinality)),
+        }
+        for fid, cardinality, dim in raw_schema["item_int"]
+    ]
+    user_dense_specs = [
+        {
+            "fid": int(fid),
+            "column": f"user_dense_feats_{fid}",
+            "observed_dim": 0,
+        }
+        for fid, _dim in raw_schema["user_dense"]
+    ]
+    seq_specs: dict[str, dict[str, Any]] = {}
+    for domain, config in sorted(raw_schema["seq"].items()):
+        prefix = str(config["prefix"])
+        ts_fid = config.get("ts_fid")
+        feature_specs: list[dict[str, Any]] = []
+        for fid, cardinality in config["features"]:
+            feature_id = int(fid)
+            if ts_fid is not None and feature_id == int(ts_fid):
+                feature_specs.append(
+                    {
+                        "fid": feature_id,
+                        "column": f"{prefix}_{feature_id}",
+                        "is_timestamp": True,
+                        "max_value": 0,
+                    }
+                )
+            else:
+                feature_specs.append(
+                    {
+                        "fid": feature_id,
+                        "column": f"{prefix}_{feature_id}",
+                        "is_timestamp": False,
+                        "counter": _ExactPositiveCardinalityCounter(int(cardinality)),
+                    }
+                )
+        seq_specs[domain] = {
+            "prefix": prefix,
+            "ts_fid": int(ts_fid) if ts_fid is not None else None,
+            "features": feature_specs,
+        }
+
+    requested_columns = [spec["column"] for spec in user_int_specs]
+    requested_columns.extend(spec["column"] for spec in item_int_specs)
+    requested_columns.extend(spec["column"] for spec in user_dense_specs)
+    for config in seq_specs.values():
+        requested_columns.extend(feature["column"] for feature in config["features"])
+
+    current_file_path: str | None = None
+    current_parquet_file: pq.ParquetFile | None = None
+    for file_path, row_group_index, _num_rows in selected_row_groups:
+        if file_path != current_file_path:
+            current_file_path = file_path
+            current_parquet_file = pq.ParquetFile(file_path)
+        if current_parquet_file is None:
+            continue
+        for batch in current_parquet_file.iter_batches(
+            batch_size=batch_size,
+            row_groups=[row_group_index],
+            columns=requested_columns,
+        ):
+            column_index = {name: index for index, name in enumerate(batch.schema.names)}
+
+            for spec in user_int_specs:
+                column = batch.column(column_index[spec["column"]])
+                if _is_list_like_arrow_type(column.type):
+                    lengths = _list_lengths(column)
+                    if lengths.size > 0:
+                        spec["observed_dim"] = max(spec["observed_dim"], int(lengths.max()))
+                    spec["counter"].add_values(_list_positive_values(column))
+                else:
+                    spec["counter"].add_values(_scalar_positive_values(column))
+
+            for spec in item_int_specs:
+                column = batch.column(column_index[spec["column"]])
+                if _is_list_like_arrow_type(column.type):
+                    lengths = _list_lengths(column)
+                    if lengths.size > 0:
+                        spec["observed_dim"] = max(spec["observed_dim"], int(lengths.max()))
+                    spec["counter"].add_values(_list_positive_values(column))
+                else:
+                    spec["counter"].add_values(_scalar_positive_values(column))
+
+            for spec in user_dense_specs:
+                column = batch.column(column_index[spec["column"]])
+                if _is_list_like_arrow_type(column.type):
+                    lengths = _list_lengths(column)
+                    if lengths.size > 0:
+                        spec["observed_dim"] = max(spec["observed_dim"], int(lengths.max()))
+                elif batch.num_rows > 0:
+                    spec["observed_dim"] = max(spec["observed_dim"], 1)
+
+            for config in seq_specs.values():
+                for feature in config["features"]:
+                    column = batch.column(column_index[feature["column"]])
+                    values = _list_positive_values(column) if _is_list_like_arrow_type(column.type) else _scalar_positive_values(column)
+                    if feature["is_timestamp"]:
+                        positive_values = values[values > 0]
+                        if positive_values.size > 0:
+                            feature["max_value"] = max(feature["max_value"], int(positive_values.max()))
+                    else:
+                        feature["counter"].add_values(values)
+
+    observed_schema = {
+        "user_int": [
+            [spec["fid"], int(spec["counter"].count), int(spec["observed_dim"])]
+            for spec in user_int_specs
+        ],
+        "item_int": [
+            [spec["fid"], int(spec["counter"].count), int(spec["observed_dim"])]
+            for spec in item_int_specs
+        ],
+        "user_dense": [
+            [spec["fid"], int(spec["observed_dim"])]
+            for spec in user_dense_specs
+        ],
+        "seq": {
+            domain: {
+                "prefix": config["prefix"],
+                "ts_fid": config["ts_fid"],
+                "features": [
+                    [feature["fid"], int(feature["max_value"]) if feature["is_timestamp"] else int(feature["counter"].count)]
+                    for feature in config["features"]
+                ],
+            }
+            for domain, config in seq_specs.items()
+        },
+    }
+    report = {
+        "dataset_role": str(dataset_role).strip() or "dataset",
+        "dataset_path": str(resolved_dataset_path),
+        "schema_path": str(resolved_schema_path),
+        "row_group_range": [start_index, end_index],
+        "row_group_count": len(selected_row_groups),
+        "row_count": int(sum(num_rows for _file_path, _rg_index, num_rows in selected_row_groups)),
+        "schema": observed_schema,
+    }
+    logging.info(
+        "Built PCVR observed schema report for %s: row_groups=%s, rows=%d",
+        report["dataset_role"],
+        report["row_group_range"],
+        report["row_count"],
+    )
+    return report
+
+
 def collect_pcvr_row_groups(data_dir: str | Path) -> list[tuple[str, int, int]]:
     data_path = Path(data_dir).expanduser()
     if data_path.is_dir():
@@ -308,6 +545,7 @@ class PCVRParquetDataset(IterableDataset):
         is_training: bool = True,
         data_pipeline_config: PCVRDataPipelineConfig | None = None,
         transforms: Sequence[PCVRBatchTransform] | None = None,
+        dataset_role: str = "dataset",
     ) -> None:
         """
         Args:
@@ -346,6 +584,9 @@ class PCVRParquetDataset(IterableDataset):
         self.buffer_batches = buffer_batches
         self.clip_vocab = clip_vocab
         self.is_training = is_training
+        self.dataset_role = str(dataset_role).strip() or "dataset"
+        self.row_group_range = row_group_range
+        self.schema_path = Path(schema_path).expanduser().resolve()
         self.data_pipeline_config = data_pipeline_config or PCVRDataPipelineConfig()
         self._strict_time_filter = bool(
             self.is_training
@@ -454,7 +695,8 @@ class PCVRParquetDataset(IterableDataset):
 
     def _load_schema(self, schema_path: str, seq_max_lens: dict[str, int]) -> None:
         """Populate per-group schema information from ``schema_path``."""
-        raw = read_path(Path(schema_path))
+        resolved_schema_path = Path(schema_path).expanduser().resolve()
+        raw = read_path(resolved_schema_path)
 
         # ---- user_int: [[fid, vocab_size, dim], ...] ----
         self._user_int_cols: list[list[int]] = raw["user_int"]
@@ -510,6 +752,25 @@ class PCVRParquetDataset(IterableDataset):
 
             # max_len: from seq_max_lens arg; unspecified domains fall back to 256.
             self._seq_maxlen[domain] = seq_max_lens.get(domain, 256)
+
+        logging.info(
+            "Loaded PCVR schema for %s dataset: path=%s, row_groups=%s, user_int=%d (%d dims), item_int=%d (%d dims), user_dense=%d (%d dims), seq_domains=%s",
+            self.dataset_role,
+            resolved_schema_path,
+            self.row_group_range if self.row_group_range is not None else "all",
+            len(self._user_int_cols),
+            self.user_int_schema.total_dim,
+            len(self._item_int_cols),
+            self.item_int_schema.total_dim,
+            len(self._user_dense_cols),
+            self.user_dense_schema.total_dim,
+            ", ".join(self.seq_domains) if self.seq_domains else "<none>",
+        )
+        logging.info(
+            "PCVR %s schema payload: %s",
+            self.dataset_role,
+            dumps(raw),
+        )
 
     def __len__(self) -> int:
         # Ceiling per Row Group; this is an upper bound on the true batch count.
@@ -1006,6 +1267,7 @@ def get_pcvr_data(
         clip_vocab=clip_vocab,
         data_pipeline_config=train_pipeline_config,
         is_training=True,
+        dataset_role="train",
     )
 
     use_cuda = torch.cuda.is_available()
@@ -1033,6 +1295,7 @@ def get_pcvr_data(
         clip_vocab=clip_vocab,
         data_pipeline_config=valid_pipeline_config,
         is_training=True,
+        dataset_role="valid",
     )
     valid_loader = DataLoader(
         valid_dataset,

--- a/src/taac2026/infrastructure/pcvr/experiment.py
+++ b/src/taac2026/infrastructure/pcvr/experiment.py
@@ -30,7 +30,7 @@ from taac2026.infrastructure.pcvr.protocol import (
     resolve_schema_path,
 )
 from taac2026.infrastructure.pcvr.tensors import sigmoid_probabilities_numpy
-from taac2026.infrastructure.pcvr.training import train_pcvr_model
+from taac2026.infrastructure.pcvr.training import parse_pcvr_train_args, train_pcvr_model
 from taac2026.infrastructure.training.runtime import RuntimeExecutionConfig, maybe_compile_callable, normalize_amp_dtype
 
 
@@ -133,10 +133,21 @@ class PCVRExperiment:
             forwarded_args.extend(["--schema_path", str(request.schema_path.expanduser().resolve())])
         forwarded_args.extend(request.extra_args)
 
+        parsed_args = parse_pcvr_train_args(
+            forwarded_args,
+            package_dir=self.package_dir,
+            defaults=self.train_defaults,
+        )
+        resolved_schema_path = resolve_schema_path(
+            request.dataset_path,
+            Path(parsed_args.schema_path) if parsed_args.schema_path else None,
+            run_dir,
+        )
+
         with self._module_context():
             import model as model_module
 
-            train_pcvr_model(
+            summary = train_pcvr_model(
                 model_module=model_module,
                 model_class_name=self.model_class_name,
                 package_dir=self.package_dir,
@@ -144,11 +155,21 @@ class PCVRExperiment:
                 argv=forwarded_args,
             )
 
-        return {
-            "experiment_name": self.name,
-            "run_dir": str(run_dir),
-            "checkpoint_root": str(run_dir),
-        }
+        observed_schema_payload = self._write_train_split_observed_schema_reports(
+            dataset_path=request.dataset_path,
+            schema_path=resolved_schema_path,
+            run_dir=run_dir,
+            valid_ratio=float(parsed_args.valid_ratio),
+            train_ratio=float(parsed_args.train_ratio),
+        )
+
+        payload = dict(summary or {})
+        payload["experiment_name"] = self.name
+        payload["run_dir"] = str(run_dir)
+        payload["checkpoint_root"] = str(run_dir)
+        payload["schema_path"] = str(resolved_schema_path)
+        payload.update(observed_schema_payload)
+        return payload
 
     def evaluate(self, request: EvalRequest) -> Mapping[str, Any]:
         checkpoint = resolve_checkpoint_path(request.run_dir, request.checkpoint_path)
@@ -194,6 +215,7 @@ class PCVRExperiment:
                 num_workers=effective_num_workers,
                 device=request.device,
                 is_training_data=request.is_training_data,
+                dataset_role="evaluation",
                 config=config,
                 runtime_execution=runtime_execution,
             )
@@ -219,6 +241,14 @@ class PCVRExperiment:
             "data_diagnostics": self._build_evaluation_data_diagnostics(request.dataset_path),
             "validation_predictions_path": str(predictions_path),
         }
+        observed_schema_path = output_path.with_name("evaluation_observed_schema.json")
+        self._write_observed_schema_report(
+            dataset_path=request.dataset_path,
+            schema_path=resolved_schema_path,
+            output_path=observed_schema_path,
+            dataset_role="eval",
+        )
+        payload["observed_schema_paths"] = {"eval": str(observed_schema_path)}
         write_json(output_path, payload)
         return payload
 
@@ -306,6 +336,7 @@ class PCVRExperiment:
                 num_workers=effective_num_workers,
                 device=request.device,
                 is_training_data=False,
+                dataset_role="inference",
                 config=config,
                 runtime_execution=runtime_execution,
             )
@@ -437,6 +468,7 @@ class PCVRExperiment:
         num_workers: int,
         device: str,
         is_training_data: bool,
+        dataset_role: str,
         config: dict[str, Any] | None = None,
         runtime_execution: RuntimeExecutionConfig | None = None,
     ) -> dict[str, Any]:
@@ -454,6 +486,7 @@ class PCVRExperiment:
             buffer_batches=0,
             clip_vocab=True,
             is_training=is_training_data,
+            dataset_role=dataset_role,
         )
         use_cuda_pinning = device.startswith("cuda") and torch.cuda.is_available()
         loader = DataLoader(dataset, batch_size=None, num_workers=num_workers, pin_memory=use_cuda_pinning)
@@ -571,6 +604,75 @@ class PCVRExperiment:
         resolved_schema_path = self._resolve_schema_path(dataset_path, schema_path, checkpoint_dir)
         logging.info("Resolved PCVR %s schema.json: %s", mode, resolved_schema_path)
         return resolved_schema_path, read_json(resolved_schema_path)
+
+    def _write_observed_schema_report(
+        self,
+        *,
+        dataset_path: Path,
+        schema_path: Path,
+        output_path: Path,
+        dataset_role: str,
+        row_group_range: tuple[int, int] | None = None,
+    ) -> Path:
+        report = pcvr_data.build_pcvr_observed_schema_report(
+            dataset_path,
+            schema_path,
+            row_group_range=row_group_range,
+            dataset_role=dataset_role,
+        )
+        write_json(output_path, report)
+        logging.info("Wrote PCVR observed schema report for %s: %s", dataset_role, output_path)
+        return output_path
+
+    def _write_train_split_observed_schema_reports(
+        self,
+        *,
+        dataset_path: Path,
+        schema_path: Path,
+        run_dir: Path,
+        valid_ratio: float,
+        train_ratio: float,
+    ) -> dict[str, Any]:
+        rg_info = pcvr_data.collect_pcvr_row_groups(dataset_path)
+        split_plan = pcvr_data.plan_pcvr_row_group_split(
+            rg_info,
+            valid_ratio=valid_ratio,
+            train_ratio=train_ratio,
+        )
+        observed_schema_paths = {
+            "train_split": str(
+                self._write_observed_schema_report(
+                    dataset_path=dataset_path,
+                    schema_path=schema_path,
+                    output_path=run_dir / "train_split_observed_schema.json",
+                    dataset_role="train_split",
+                    row_group_range=split_plan.train_row_group_range,
+                )
+            ),
+            "valid_split": str(
+                self._write_observed_schema_report(
+                    dataset_path=dataset_path,
+                    schema_path=schema_path,
+                    output_path=run_dir / "valid_split_observed_schema.json",
+                    dataset_role="valid_split",
+                    row_group_range=split_plan.valid_row_group_range,
+                )
+            ),
+        }
+        return {
+            "observed_schema_paths": observed_schema_paths,
+            "row_group_split": {
+                "train_row_groups": split_plan.train_row_groups,
+                "valid_row_groups": split_plan.valid_row_groups,
+                "train_row_group_range": list(split_plan.train_row_group_range),
+                "valid_row_group_range": list(split_plan.valid_row_group_range),
+                "train_rows": split_plan.train_rows,
+                "valid_rows": split_plan.valid_rows,
+                "reuse_train_for_valid": split_plan.reuse_train_for_valid,
+                "is_disjoint": split_plan.is_disjoint,
+                "is_l1_ready": split_plan.is_l1_ready,
+            },
+        }
 
     def _resolve_schema_path(self, dataset_path: Path, schema_path: Path | None, checkpoint_dir: Path) -> Path:
         return resolve_schema_path(dataset_path, schema_path, checkpoint_dir)

--- a/tests/unit/test_package_inference.py
+++ b/tests/unit/test_package_inference.py
@@ -91,6 +91,7 @@ def test_build_inference_bundle_contains_runtime_sources(tmp_path: Path) -> None
     assert "code_package.zip" in infer_script
     assert ".taac_inference_manifest.json" in infer_script
     assert "TAAC_INSTALL_PROJECT_DEPS" in infer_script
+    assert "TAAC_BUNDLE_PIP_EXTRAS" in infer_script
     assert "mirrors.cloud.tencent.com/pypi/simple" in infer_script
     assert "taac2026.application.evaluation.infer" in infer_script
 
@@ -99,6 +100,7 @@ def test_build_inference_bundle_contains_runtime_sources(tmp_path: Path) -> None
     assert manifest["bundled_experiment_path"] == "config/baseline"
     assert manifest["entrypoint"] == "infer.py"
     assert manifest["code_package"] == "code_package.zip"
+    assert manifest["runtime_env"]["pip_extras"].startswith("TAAC_BUNDLE_PIP_EXTRAS")
 
     names = _code_package_names(result.code_package_path)
     assert "project/.taac_inference_manifest.json" in names
@@ -159,6 +161,7 @@ def test_generated_infer_script_requires_user_cache_path_without_workdir_overrid
         "TAAC_EXPERIMENT",
         "TAAC_FORCE_EXTRACT",
         "TAAC_INSTALL_PROJECT_DEPS",
+        "TAAC_BUNDLE_PIP_EXTRAS",
         "TAAC_PIP_EXTRA_ARGS",
         "TAAC_PIP_EXTRAS",
         "TAAC_PIP_INDEX_URL",
@@ -192,6 +195,7 @@ def test_generated_infer_script_prefers_user_cache_path_when_available(tmp_path:
         "TAAC_EXPERIMENT",
         "TAAC_FORCE_EXTRACT",
         "TAAC_INSTALL_PROJECT_DEPS",
+        "TAAC_BUNDLE_PIP_EXTRAS",
         "TAAC_PIP_EXTRA_ARGS",
         "TAAC_PIP_EXTRAS",
         "TAAC_PIP_INDEX_URL",
@@ -232,6 +236,7 @@ def test_generated_infer_script_installs_project_dependencies_before_entrypoint(
         "TAAC_EXPERIMENT",
         "TAAC_FORCE_EXTRACT",
         "TAAC_INSTALL_PROJECT_DEPS",
+        "TAAC_BUNDLE_PIP_EXTRAS",
         "TAAC_PIP_EXTRA_ARGS",
         "TAAC_PIP_EXTRAS",
         "TAAC_PIP_INDEX_URL",
@@ -240,6 +245,7 @@ def test_generated_infer_script_installs_project_dependencies_before_entrypoint(
         env.pop(variable, None)
     env.update(
         {
+            "TAAC_PIP_EXTRAS": "dev",
             "TAAC_PIP_EXTRA_ARGS": "-q",
             "TAAC_PIP_INDEX_URL": "",
             "PYTHONPATH": str(fake_pip),
@@ -263,6 +269,50 @@ def test_generated_infer_script_installs_project_dependencies_before_entrypoint(
     assert "Installing TAAC project dependencies from pyproject.toml" in completed.stderr
 
 
+def test_generated_infer_script_accepts_explicit_bundle_pip_extras(tmp_path: Path) -> None:
+    output_dir = tmp_path / "baseline_bundle"
+    user_cache_path = tmp_path / "user_cache"
+    result = build_inference_bundle("config/baseline", output_dir=output_dir)
+    _write_minimal_runtime_package(result.code_package_path)
+    pip_args_path = tmp_path / "pip_args.json"
+    fake_pip = _write_fake_pip_package(tmp_path, pip_args_path)
+
+    env = os.environ.copy()
+    for variable in (
+        "TAAC_BUNDLE_WORKDIR",
+        "TAAC_CODE_PACKAGE",
+        "TAAC_EXPERIMENT",
+        "TAAC_FORCE_EXTRACT",
+        "TAAC_INSTALL_PROJECT_DEPS",
+        "TAAC_BUNDLE_PIP_EXTRAS",
+        "TAAC_PIP_EXTRA_ARGS",
+        "TAAC_PIP_EXTRAS",
+        "TAAC_PIP_INDEX_URL",
+        "TAAC_SKIP_PIP_INSTALL",
+    ):
+        env.pop(variable, None)
+    env.update(
+        {
+            "TAAC_BUNDLE_PIP_EXTRAS": "dev",
+            "TAAC_PIP_EXTRA_ARGS": "-q",
+            "TAAC_PIP_INDEX_URL": "",
+            "PYTHONPATH": str(fake_pip),
+            "USER_CACHE_PATH": str(user_cache_path),
+        }
+    )
+    subprocess.run(
+        [sys.executable, str(result.run_script_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    pip_args = loads(pip_args_path.read_bytes())
+
+    assert pip_args == ["install", "--disable-pip-version-check", "-q", ".[dev]"]
+
+
 def test_package_inference_main_prints_human_readable_summary_by_default(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -281,6 +331,7 @@ def test_package_inference_main_prints_human_readable_summary_by_default(
                 "dataset_path": "EVAL_DATA_PATH",
                 "result_path": "EVAL_RESULT_PATH",
                 "schema_path": "TAAC_SCHEMA_PATH",
+                "pip_extras": "TAAC_BUNDLE_PIP_EXTRAS (optional; defaults to runtime-only install with no dev extra)",
             },
         },
     )

--- a/tests/unit/test_package_training.py
+++ b/tests/unit/test_package_training.py
@@ -96,6 +96,7 @@ def test_build_training_bundle_contains_runtime_sources(tmp_path: Path) -> None:
     run_script = result.run_script_path.read_text(encoding="utf-8")
     assert "RUNNER_MODE=\"python\"" in run_script
     assert "TAAC_INSTALL_PROJECT_DEPS" in run_script
+    assert "TAAC_BUNDLE_PIP_EXTRAS" in run_script
     assert "mirrors.cloud.tencent.com/pypi/simple" in run_script
     assert "python -m taac2026.application.training.cli" not in run_script
     assert "run_console_script taac-train taac2026.application.training.cli" in run_script
@@ -105,6 +106,7 @@ def test_build_training_bundle_contains_runtime_sources(tmp_path: Path) -> None:
     assert manifest["bundled_experiment_path"] == "config/baseline"
     assert manifest["entrypoint"] == "run.sh"
     assert manifest["code_package"] == "code_package.zip"
+    assert manifest["runtime_env"]["pip_extras"].startswith("TAAC_BUNDLE_PIP_EXTRAS")
 
     names = _code_package_names(result.code_package_path)
     assert "project/.taac_training_manifest.json" in names
@@ -182,6 +184,7 @@ def test_training_run_script_installs_project_dependencies_before_entrypoint(tmp
         "TAAC_EXPERIMENT",
         "TAAC_FORCE_EXTRACT",
         "TAAC_INSTALL_PROJECT_DEPS",
+        "TAAC_BUNDLE_PIP_EXTRAS",
         "TAAC_PIP_EXTRA_ARGS",
         "TAAC_PIP_EXTRAS",
         "TAAC_PIP_INDEX_URL",
@@ -193,6 +196,7 @@ def test_training_run_script_installs_project_dependencies_before_entrypoint(tmp
     env.update(
         {
             "TAAC_BUNDLE_WORKDIR": str(tmp_path / "bundle_workdir"),
+            "TAAC_PIP_EXTRAS": "dev",
             "TAAC_PIP_EXTRA_ARGS": "-q",
             "TAAC_PIP_INDEX_URL": "",
             "TAAC_PYTHON": sys.executable,
@@ -218,6 +222,54 @@ def test_training_run_script_installs_project_dependencies_before_entrypoint(tmp
     assert "Installing TAAC project dependencies from pyproject.toml" in completed.stderr
 
 
+def test_training_run_script_accepts_explicit_bundle_pip_extras(tmp_path: Path) -> None:
+    output_dir = tmp_path / "baseline_bundle"
+    result = build_training_bundle("config/baseline", output_dir=output_dir)
+    _write_minimal_training_runtime_package(result.code_package_path)
+    pip_args_path = tmp_path / "pip_args.json"
+    fake_pip = _write_fake_pip_package(tmp_path, pip_args_path)
+
+    env = os.environ.copy()
+    for variable in (
+        "TAAC_BUNDLE_WORKDIR",
+        "TAAC_CODE_PACKAGE",
+        "TAAC_EXPERIMENT",
+        "TAAC_FORCE_EXTRACT",
+        "TAAC_INSTALL_PROJECT_DEPS",
+        "TAAC_BUNDLE_PIP_EXTRAS",
+        "TAAC_PIP_EXTRA_ARGS",
+        "TAAC_PIP_EXTRAS",
+        "TAAC_PIP_INDEX_URL",
+        "TAAC_PYTHON",
+        "TAAC_RUNNER",
+        "TAAC_SKIP_PIP_INSTALL",
+    ):
+        env.pop(variable, None)
+    env.update(
+        {
+            "TAAC_BUNDLE_WORKDIR": str(tmp_path / "bundle_workdir"),
+            "TAAC_BUNDLE_PIP_EXTRAS": "dev",
+            "TAAC_PIP_EXTRA_ARGS": "-q",
+            "TAAC_PIP_INDEX_URL": "",
+            "TAAC_PYTHON": sys.executable,
+            "TAAC_RUNNER": "python",
+            "PYTHONPATH": str(fake_pip),
+        }
+    )
+
+    subprocess.run(
+        ["bash", str(result.run_script_path), "--device", "cpu"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    pip_args = loads(pip_args_path.read_bytes())
+
+    assert pip_args == ["install", "--disable-pip-version-check", "-q", ".[dev]"]
+
+
 def test_package_training_main_prints_human_readable_summary_by_default(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -236,6 +288,7 @@ def test_package_training_main_prints_human_readable_summary_by_default(
                 "schema_path": "TAAC_SCHEMA_PATH",
                 "checkpoint_path": "TAAC_OUTPUT_DIR or TRAIN_CKPT_PATH",
                 "cuda_profile": "TAAC_CUDA_PROFILE",
+                "pip_extras": "TAAC_BUNDLE_PIP_EXTRAS (optional; defaults to runtime-only install with no dev extra)",
             },
         },
     )

--- a/tests/unit/test_pcvr_data_augmentation.py
+++ b/tests/unit/test_pcvr_data_augmentation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pyarrow as pa
@@ -233,3 +234,57 @@ def test_strict_time_filter_removes_future_sequence_events(tmp_path: Path) -> No
     assert batch["seq_a"].tolist() == [[[1, 3, 0]]]
     assert batch["seq_a_time_bucket"][0, :2].gt(0).all()
     assert batch["seq_a_time_bucket"][0, 2].item() == 0
+
+
+def test_dataset_logs_schema_payload_with_dataset_role(tmp_path: Path, caplog) -> None:
+    schema_path = tmp_path / "schema.json"
+    parquet_path = tmp_path / "demo.parquet"
+    schema = {
+        "user_int": [[1, 10, 1]],
+        "item_int": [[2, 10, 1]],
+        "user_dense": [[3, 2]],
+        "seq": {
+            "seq_a": {
+                "prefix": "domain_a_seq",
+                "ts_fid": 10,
+                "features": [[10, 1000], [11, 100]],
+            }
+        },
+    }
+    schema_path.write_text(dumps(schema), encoding="utf-8")
+    table = pa.table(
+        {
+            "timestamp": [100],
+            "label_type": [2],
+            "user_id": ["u0"],
+            "user_int_feats_1": [1],
+            "item_int_feats_2": [2],
+            "user_dense_feats_3": [[0.1, 0.2]],
+            "domain_a_seq_10": [[10]],
+            "domain_a_seq_11": [[1]],
+        }
+    )
+    pq.write_table(table, parquet_path, row_group_size=1)
+
+    with caplog.at_level(logging.INFO):
+        PCVRParquetDataset(
+            parquet_path=str(parquet_path),
+            schema_path=str(schema_path),
+            batch_size=1,
+            seq_max_lens={"seq_a": 1},
+            shuffle=False,
+            buffer_batches=0,
+            dataset_role="train",
+        )
+
+    assert "Loaded PCVR schema for train dataset" in caplog.text
+    assert str(schema_path.resolve()) in caplog.text
+    assert "PCVR train schema payload" in caplog.text
+    payload_message = next(
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("PCVR train schema payload: ")
+    )
+    assert "\n" not in payload_message
+    assert '"user_int":[[1,10,1]]' in payload_message
+    assert '"prefix":"domain_a_seq"' in payload_message

--- a/tests/unit/test_pcvr_data_split.py
+++ b/tests/unit/test_pcvr_data_split.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pyarrow as pa
+import pyarrow.parquet as pq
 from torch.utils.data import IterableDataset
 
 import taac2026.infrastructure.pcvr.data as pcvr_data
+from taac2026.infrastructure.io.json_utils import dumps
 from taac2026.infrastructure.pcvr.config import (
     PCVRDataCacheConfig,
     PCVRDataPipelineConfig,
@@ -18,10 +21,12 @@ class _FakeDataset(IterableDataset):
         *_args,
         row_group_range: tuple[int, int] | None = None,
         data_pipeline_config: PCVRDataPipelineConfig | None = None,
+        dataset_role: str = "dataset",
         **_kwargs,
     ) -> None:
         self.row_group_range = row_group_range
         self.data_pipeline_config = data_pipeline_config
+        self.dataset_role = dataset_role
 
     def __iter__(self):
         return iter(())
@@ -55,6 +60,36 @@ def _patch_parquet_runtime(monkeypatch, row_group_rows: list[int]) -> None:
     )
 
 
+def _write_observed_schema_fixture(schema_path: Path, parquet_path: Path) -> None:
+    schema = {
+        "user_int": [[1, 10, 1], [2, 20, 4]],
+        "item_int": [[3, 10, 1]],
+        "user_dense": [[4, 4]],
+        "seq": {
+            "seq_a": {
+                "prefix": "domain_a_seq",
+                "ts_fid": 10,
+                "features": [[10, 0], [11, 20]],
+            }
+        },
+    }
+    schema_path.write_text(dumps(schema), encoding="utf-8")
+    pq.write_table(
+        pa.table(
+            {
+                "user_int_feats_1": [1, 2],
+                "user_int_feats_2": [[1, 2], [2, 3, 4]],
+                "item_int_feats_3": [3, 4],
+                "user_dense_feats_4": [[0.1, 0.2, 0.3], [0.9]],
+                "domain_a_seq_10": [[100, 101], [103]],
+                "domain_a_seq_11": [[5, 6], [6, 7, 7]],
+            }
+        ),
+        parquet_path,
+        row_group_size=1,
+    )
+
+
 def test_get_pcvr_data_reuses_single_row_group_for_validation(
     monkeypatch, tmp_path: Path
 ) -> None:
@@ -71,8 +106,11 @@ def test_get_pcvr_data_reuses_single_row_group_for_validation(
     )
 
     assert train_dataset.row_group_range == (0, 1)
+    assert train_dataset.dataset_role == "train"
     assert train_loader.dataset.row_group_range == (0, 1)
+    assert train_loader.dataset.dataset_role == "train"
     assert valid_loader.dataset.row_group_range == (0, 1)
+    assert valid_loader.dataset.dataset_role == "valid"
 
     split_plan = pcvr_data.plan_pcvr_row_group_split([("demo.parquet", 0, 1000)])
     assert split_plan.reuse_train_for_valid is True
@@ -96,8 +134,11 @@ def test_get_pcvr_data_keeps_disjoint_ranges_when_multiple_row_groups(
     )
 
     assert train_dataset.row_group_range == (0, 2)
+    assert train_dataset.dataset_role == "train"
     assert train_loader.dataset.row_group_range == (0, 2)
+    assert train_loader.dataset.dataset_role == "train"
     assert valid_loader.dataset.row_group_range == (2, 3)
+    assert valid_loader.dataset.dataset_role == "valid"
 
     split_plan = pcvr_data.plan_pcvr_row_group_split(
         [
@@ -140,3 +181,38 @@ def test_get_pcvr_data_applies_augmentation_only_to_train_dataset(
     assert valid_loader.dataset.data_pipeline_config.transforms == ()
     assert train_loader.dataset.data_pipeline_config.cache == data_pipeline_config.cache
     assert valid_loader.dataset.data_pipeline_config.cache == data_pipeline_config.cache
+
+
+def test_build_pcvr_observed_schema_report_respects_row_group_range(tmp_path: Path) -> None:
+    schema_path = tmp_path / "schema.json"
+    parquet_path = tmp_path / "demo.parquet"
+    _write_observed_schema_fixture(schema_path, parquet_path)
+
+    train_report = pcvr_data.build_pcvr_observed_schema_report(
+        parquet_path,
+        schema_path,
+        row_group_range=(0, 1),
+        dataset_role="train_split",
+    )
+    valid_report = pcvr_data.build_pcvr_observed_schema_report(
+        parquet_path,
+        schema_path,
+        row_group_range=(1, 2),
+        dataset_role="valid_split",
+    )
+
+    assert train_report["dataset_role"] == "train_split"
+    assert train_report["row_group_range"] == [0, 1]
+    assert train_report["row_count"] == 1
+    assert train_report["schema"]["user_int"] == [[1, 1, 1], [2, 2, 2]]
+    assert train_report["schema"]["item_int"] == [[3, 1, 1]]
+    assert train_report["schema"]["user_dense"] == [[4, 3]]
+    assert train_report["schema"]["seq"]["seq_a"]["features"] == [[10, 101], [11, 2]]
+
+    assert valid_report["dataset_role"] == "valid_split"
+    assert valid_report["row_group_range"] == [1, 2]
+    assert valid_report["row_count"] == 1
+    assert valid_report["schema"]["user_int"] == [[1, 1, 1], [2, 3, 3]]
+    assert valid_report["schema"]["item_int"] == [[3, 1, 1]]
+    assert valid_report["schema"]["user_dense"] == [[4, 1]]
+    assert valid_report["schema"]["seq"]["seq_a"]["features"] == [[10, 103], [11, 2]]

--- a/tests/unit/test_pcvr_infer_runtime.py
+++ b/tests/unit/test_pcvr_infer_runtime.py
@@ -4,9 +4,11 @@ import logging
 from pathlib import Path
 from types import ModuleType
 
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 
-from taac2026.domain.config import EvalRequest, InferRequest
+from taac2026.domain.config import EvalRequest, InferRequest, TrainRequest
 from taac2026.infrastructure.io.json_utils import dumps, loads
 from taac2026.infrastructure.pcvr.config import PCVRDataConfig, PCVRTrainConfig
 import taac2026.infrastructure.pcvr.experiment as experiment_module
@@ -17,11 +19,42 @@ from taac2026.infrastructure.training.runtime import RuntimeExecutionConfig
 def _make_experiment(tmp_path: Path, *, train_defaults: PCVRTrainConfig | None = None) -> PCVRExperiment:
     package_dir = tmp_path / "package"
     package_dir.mkdir()
+    (package_dir / "model.py").write_text("class DummyModel:\n    pass\n", encoding="utf-8")
     return PCVRExperiment(
         name="pcvr_symbiosis",
         package_dir=package_dir,
         model_class_name="DummyModel",
         train_defaults=train_defaults or PCVRTrainConfig(),
+    )
+
+
+def _write_observed_schema_fixture(schema_path: Path, parquet_path: Path) -> None:
+    payload = {
+        "user_int": [[1, 10, 1], [2, 20, 4]],
+        "item_int": [[3, 20, 1]],
+        "user_dense": [[4, 4]],
+        "seq": {
+            "seq_a": {
+                "prefix": "domain_a_seq",
+                "ts_fid": 10,
+                "features": [[10, 0], [11, 20]],
+            }
+        },
+    }
+    schema_path.write_text(dumps(payload), encoding="utf-8")
+    pq.write_table(
+        pa.table(
+            {
+                "user_int_feats_1": [1, 2],
+                "user_int_feats_2": [[1, 2], [2, 3, 4]],
+                "item_int_feats_3": [10, 11],
+                "user_dense_feats_4": [[0.1, 0.2], [0.3]],
+                "domain_a_seq_10": [[100, 101], [103]],
+                "domain_a_seq_11": [[5, 6], [6, 7, 7]],
+            }
+        ),
+        parquet_path,
+        row_group_size=1,
     )
 
 
@@ -112,6 +145,43 @@ def test_infer_uses_train_config_runtime_settings(tmp_path: Path, monkeypatch: p
     assert loads((tmp_path / "results" / "predictions.json").read_bytes()) == {
         "predictions": {"u1": 0.5},
     }
+
+
+def test_train_writes_split_observed_schema_reports(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    experiment = _make_experiment(tmp_path)
+    dataset_path = tmp_path / "train.parquet"
+    schema_path = tmp_path / "schema.json"
+    run_dir = tmp_path / "outputs"
+    _write_observed_schema_fixture(schema_path, dataset_path)
+
+    monkeypatch.setattr(
+        experiment_module,
+        "train_pcvr_model",
+        lambda **kwargs: {"run_dir": str(run_dir.resolve()), "checkpoint_root": str(run_dir.resolve())},
+    )
+
+    payload = experiment.train(
+        TrainRequest(
+            experiment="config/symbiosis",
+            dataset_path=dataset_path,
+            schema_path=schema_path,
+            run_dir=run_dir,
+        )
+    )
+
+    observed_paths = payload["observed_schema_paths"]
+    assert set(observed_paths) == {"train_split", "valid_split"}
+    train_report = loads(Path(observed_paths["train_split"]).read_bytes())
+    valid_report = loads(Path(observed_paths["valid_split"]).read_bytes())
+    assert train_report["dataset_role"] == "train_split"
+    assert valid_report["dataset_role"] == "valid_split"
+    assert payload["row_group_split"]["train_row_group_range"] == [0, 1]
+    assert payload["row_group_split"]["valid_row_group_range"] == [1, 2]
+    assert train_report["schema"]["user_int"] == [[1, 1, 1], [2, 2, 2]]
+    assert valid_report["schema"]["user_int"] == [[1, 1, 1], [2, 3, 3]]
 
 
 def test_resolve_prediction_runtime_execution_requires_train_config_values(tmp_path: Path) -> None:
@@ -239,6 +309,7 @@ def test_run_prediction_loop_loads_safetensors_via_checkpoint_helper(
         num_workers=0,
         device="cpu",
         is_training_data=False,
+        dataset_role="inference",
         config={"seq_max_lens": "{}"},
     )
 
@@ -252,9 +323,22 @@ def test_evaluate_writes_score_diagnostics(tmp_path: Path, monkeypatch: pytest.M
     checkpoint_dir.mkdir()
     checkpoint_path = checkpoint_dir / "model.safetensors"
     checkpoint_path.write_bytes(b"checkpoint")
-    schema_payload = {"features": [{"name": "label"}]}
+    schema_payload = {
+        "user_int": [[1, 10, 1], [2, 20, 4]],
+        "item_int": [[3, 20, 1]],
+        "user_dense": [[4, 4]],
+        "seq": {
+            "seq_a": {
+                "prefix": "domain_a_seq",
+                "ts_fid": 10,
+                "features": [[10, 0], [11, 20]],
+            }
+        },
+    }
     (checkpoint_dir / "schema.json").write_text(dumps(schema_payload), encoding="utf-8")
     _write_train_config(checkpoint_dir)
+    dataset_path = tmp_path / "eval.parquet"
+    _write_observed_schema_fixture(checkpoint_dir / "schema.json", dataset_path)
 
     def fake_bound_run_prediction_loop(self, **kwargs):
         del self, kwargs
@@ -268,14 +352,10 @@ def test_evaluate_writes_score_diagnostics(tmp_path: Path, monkeypatch: pytest.M
         }
 
     monkeypatch.setattr(PCVRExperiment, "_run_prediction_loop", fake_bound_run_prediction_loop)
-    monkeypatch.setattr(
-        "taac2026.infrastructure.pcvr.experiment.pcvr_data.collect_pcvr_row_groups",
-        lambda _path: [(str(tmp_path / "eval.parquet"), 0, 2), (str(tmp_path / "eval.parquet"), 1, 2)],
-    )
     output_path = tmp_path / "evaluation.json"
     request = EvalRequest(
         experiment="config/symbiosis",
-        dataset_path=tmp_path / "eval.parquet",
+        dataset_path=dataset_path,
         schema_path=None,
         run_dir=checkpoint_dir,
         checkpoint_path=checkpoint_path,
@@ -293,10 +373,16 @@ def test_evaluate_writes_score_diagnostics(tmp_path: Path, monkeypatch: pytest.M
     assert payload["data_diagnostics"]["row_group_split"]["is_l1_ready"] is True
     assert payload["schema_path"] == str((checkpoint_dir / "schema.json").resolve())
     assert payload["schema"] == schema_payload
+    observed_schema_path = Path(payload["observed_schema_paths"]["eval"])
+    assert observed_schema_path.exists()
+    observed_schema_payload = loads(observed_schema_path.read_bytes())
+    assert observed_schema_payload["dataset_role"] == "eval"
+    assert observed_schema_payload["schema"]["user_int"] == [[1, 2, 1], [2, 4, 3]]
     saved_payload = loads(output_path.read_bytes())
     assert saved_payload["metrics"]["score_diagnostics"] == diagnostics
     assert saved_payload["data_diagnostics"] == payload["data_diagnostics"]
     assert saved_payload["schema"] == schema_payload
+    assert saved_payload["observed_schema_paths"] == payload["observed_schema_paths"]
     predictions_payload = (tmp_path / "predictions.jsonl").read_bytes()
     assert predictions_payload.endswith(b"\n")
     assert [loads(line) for line in predictions_payload.splitlines()] == [

--- a/uv.lock
+++ b/uv.lock
@@ -192,6 +192,15 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.3.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+]
+
+[[package]]
 name = "cloudpickle"
 version = "3.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -288,6 +297,70 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.13.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/cc/5cb9502f4e01972f54eedd48218bb203fe81e294be606a2bc93970208013/coverage-7.13.5-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:704de6328e3d612a8f6c07000a878ff38181ec3263d5a11da1db294fa6a9bdf8", size = 246532, upload-time = "2026-03-17T10:29:54.688Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/d8/3217636d86c7e7b12e126e4f30ef1581047da73140614523af7495ed5f2d/coverage-7.13.5-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a1a6d79a14e1ec1832cabc833898636ad5f3754a678ef8bb4908515208bf84f4", size = 248333, upload-time = "2026-03-17T10:29:56.221Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/30/2002ac6729ba2d4357438e2ed3c447ad8562866c8c63fc16f6dfc33afe56/coverage-7.13.5-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79060214983769c7ba3f0cee10b54c97609dca4d478fa1aa32b914480fd5738d", size = 250211, upload-time = "2026-03-17T10:29:57.938Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/85/552496626d6b9359eb0e2f86f920037c9cbfba09b24d914c6e1528155f7d/coverage-7.13.5-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:356e76b46783a98c2a2fe81ec79df4883a1e62895ea952968fb253c114e7f930", size = 252125, upload-time = "2026-03-17T10:29:59.388Z" },
+    { url = "https://files.pythonhosted.org/packages/44/21/40256eabdcbccdb6acf6b381b3016a154399a75fe39d406f790ae84d1f3c/coverage-7.13.5-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0cef0cdec915d11254a7f549c1170afecce708d30610c6abdded1f74e581666d", size = 247219, upload-time = "2026-03-17T10:30:01.199Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e8/96e2a6c3f21a0ea77d7830b254a1542d0328acc8d7bdf6a284ba7e529f77/coverage-7.13.5-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:dc022073d063b25a402454e5712ef9e007113e3a676b96c5f29b2bda29352f40", size = 248248, upload-time = "2026-03-17T10:30:03.317Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ba/8477f549e554827da390ec659f3c38e4b6d95470f4daafc2d8ff94eaa9c2/coverage-7.13.5-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:9b74db26dfea4f4e50d48a4602207cd1e78be33182bc9cbf22da94f332f99878", size = 246254, upload-time = "2026-03-17T10:30:04.832Z" },
+    { url = "https://files.pythonhosted.org/packages/55/59/bc22aef0e6aa179d5b1b001e8b3654785e9adf27ef24c93dc4228ebd5d68/coverage-7.13.5-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:ad146744ca4fd09b50c482650e3c1b1f4dfa1d4792e0a04a369c7f23336f0400", size = 250067, upload-time = "2026-03-17T10:30:06.535Z" },
+    { url = "https://files.pythonhosted.org/packages/de/1b/c6a023a160806a5137dca53468fd97530d6acad24a22003b1578a9c2e429/coverage-7.13.5-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:c555b48be1853fe3997c11c4bd521cdd9a9612352de01fa4508f16ec341e6fe0", size = 246521, upload-time = "2026-03-17T10:30:08.486Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/3f/3532c85a55aa2f899fa17c186f831cfa1aa434d88ff792a709636f64130e/coverage-7.13.5-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7034b5c56a58ae5e85f23949d52c14aca2cfc6848a31764995b7de88f13a1ea0", size = 247126, upload-time = "2026-03-17T10:30:09.966Z" },
+    { url = "https://files.pythonhosted.org/packages/55/2f/e0e5b237bffdb5d6c530ce87cc1d413a5b7d7dfd60fb067ad6d254c35c76/coverage-7.13.5-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:0672854dc733c342fa3e957e0605256d2bf5934feeac328da9e0b5449634a642", size = 250303, upload-time = "2026-03-17T10:30:17.748Z" },
+    { url = "https://files.pythonhosted.org/packages/92/be/b1afb692be85b947f3401375851484496134c5554e67e822c35f28bf2fbc/coverage-7.13.5-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ec10e2a42b41c923c2209b846126c6582db5e43a33157e9870ba9fb70dc7854b", size = 252218, upload-time = "2026-03-17T10:30:19.804Z" },
+    { url = "https://files.pythonhosted.org/packages/da/69/2f47bb6fa1b8d1e3e5d0c4be8ccb4313c63d742476a619418f85740d597b/coverage-7.13.5-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be3d4bbad9d4b037791794ddeedd7d64a56f5933a2c1373e18e9e568b9141686", size = 254326, upload-time = "2026-03-17T10:30:21.321Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d0/79db81da58965bd29dabc8f4ad2a2af70611a57cba9d1ec006f072f30a54/coverage-7.13.5-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4d2afbc5cc54d286bfb54541aa50b64cdb07a718227168c87b9e2fb8f25e1743", size = 256267, upload-time = "2026-03-17T10:30:23.094Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/32/d0d7cc8168f91ddab44c0ce4806b969df5f5fdfdbb568eaca2dbc2a04936/coverage-7.13.5-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3ad050321264c49c2fa67bb599100456fc51d004b82534f379d16445da40fb75", size = 250430, upload-time = "2026-03-17T10:30:25.311Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/06/a055311d891ddbe231cd69fdd20ea4be6e3603ffebddf8704b8ca8e10a3c/coverage-7.13.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7300c8a6d13335b29bb76d7651c66af6bd8658517c43499f110ddc6717bfc209", size = 252017, upload-time = "2026-03-17T10:30:27.284Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f6/d0fd2d21e29a657b5f77a2fe7082e1568158340dceb941954f776dce1b7b/coverage-7.13.5-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:eb07647a5738b89baab047f14edd18ded523de60f3b30e75c2acc826f79c839a", size = 250080, upload-time = "2026-03-17T10:30:29.481Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ab/0d7fb2efc2e9a5eb7ddcc6e722f834a69b454b7e6e5888c3a8567ecffb31/coverage-7.13.5-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:9adb6688e3b53adffefd4a52d72cbd8b02602bfb8f74dcd862337182fd4d1a4e", size = 253843, upload-time = "2026-03-17T10:30:31.301Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/6f/7467b917bbf5408610178f62a49c0ed4377bb16c1657f689cc61470da8ce/coverage-7.13.5-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7c8d4bc913dd70b93488d6c496c77f3aff5ea99a07e36a18f865bca55adef8bd", size = 249802, upload-time = "2026-03-17T10:30:33.358Z" },
+    { url = "https://files.pythonhosted.org/packages/75/2c/1172fb689df92135f5bfbbd69fc83017a76d24ea2e2f3a1154007e2fb9f8/coverage-7.13.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0e3c426ffc4cd952f54ee9ffbdd10345709ecc78a3ecfd796a57236bfad0b9b8", size = 250707, upload-time = "2026-03-17T10:30:35.2Z" },
+    { url = "https://files.pythonhosted.org/packages/29/72/20b917c6793af3a5ceb7fb9c50033f3ec7865f2911a1416b34a7cfa0813b/coverage-7.13.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6e3370441f4513c6252bf042b9c36d22491142385049243253c7e48398a15a9f", size = 251419, upload-time = "2026-03-17T10:30:45.545Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/49/cd14b789536ac6a4778c453c6a2338bc0a2fb60c5a5a41b4008328b9acc1/coverage-7.13.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:03ccc709a17a1de074fb1d11f217342fb0d2b1582ed544f554fc9fc3f07e95f5", size = 254159, upload-time = "2026-03-17T10:30:47.204Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/00/7b0edcfe64e2ed4c0340dac14a52ad0f4c9bd0b8b5e531af7d55b703db7c/coverage-7.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f4818d065964db3c1c66dc0fbdac5ac692ecbc875555e13374fdbe7eedb4376", size = 255270, upload-time = "2026-03-17T10:30:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/93/89/7ffc4ba0f5d0a55c1e84ea7cee39c9fc06af7b170513d83fbf3bbefce280/coverage-7.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:012d5319e66e9d5a218834642d6c35d265515a62f01157a45bcc036ecf947256", size = 257538, upload-time = "2026-03-17T10:30:50.77Z" },
+    { url = "https://files.pythonhosted.org/packages/81/bd/73ddf85f93f7e6fa83e77ccecb6162d9415c79007b4bc124008a4995e4a7/coverage-7.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8dd02af98971bdb956363e4827d34425cb3df19ee550ef92855b0acb9c7ce51c", size = 251821, upload-time = "2026-03-17T10:30:52.5Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/81/278aff4e8dec4926a0bcb9486320752811f543a3ce5b602cc7a29978d073/coverage-7.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f08fd75c50a760c7eb068ae823777268daaf16a80b918fa58eea888f8e3919f5", size = 253191, upload-time = "2026-03-17T10:30:54.543Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ee/fe1621488e2e0a58d7e94c4800f0d96f79671553488d401a612bebae324b/coverage-7.13.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:843ea8643cf967d1ac7e8ecd4bb00c99135adf4816c0c0593fdcc47b597fcf09", size = 251337, upload-time = "2026-03-17T10:30:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a6/f79fb37aa104b562207cc23cb5711ab6793608e246cae1e93f26b2236ed9/coverage-7.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:9d44d7aa963820b1b971dbecd90bfe5fe8f81cff79787eb6cca15750bd2f79b9", size = 255404, upload-time = "2026-03-17T10:30:58.427Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f0/ed15262a58ec81ce457ceb717b7f78752a1713556b19081b76e90896e8d4/coverage-7.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7132bed4bd7b836200c591410ae7d97bf7ae8be6fc87d160b2bd881df929e7bf", size = 250903, upload-time = "2026-03-17T10:31:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e9/9129958f20e7e9d4d56d51d42ccf708d15cac355ff4ac6e736e97a9393d2/coverage-7.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a698e363641b98843c517817db75373c83254781426e94ada3197cabbc2c919c", size = 252780, upload-time = "2026-03-17T10:31:01.916Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/13/93419671cee82b780bab7ea96b67c8ef448f5f295f36bf5031154ec9a790/coverage-7.13.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:da305e9937617ee95c2e39d8ff9f040e0487cbf1ac174f777ed5eddd7a7c1f26", size = 250935, upload-time = "2026-03-17T10:31:12.392Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/68/1666e3a4462f8202d836920114fa7a5ee9275d1fa45366d336c551a162dd/coverage-7.13.5-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:78e696e1cc714e57e8b25760b33a8b1026b7048d270140d25dafe1b0a1ee05a3", size = 253541, upload-time = "2026-03-17T10:31:14.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/5e/3ee3b835647be646dcf3c65a7c6c18f87c27326a858f72ab22c12730773d/coverage-7.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02ca0eed225b2ff301c474aeeeae27d26e2537942aa0f87491d3e147e784a82b", size = 254780, upload-time = "2026-03-17T10:31:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/cb5bd1a04cfcc49ede6cd8409d80bee17661167686741e041abc7ee1b9a9/coverage-7.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:04690832cbea4e4663d9149e05dba142546ca05cb1848816760e7f58285c970a", size = 256912, upload-time = "2026-03-17T10:31:17.89Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/66/c1dceb7b9714473800b075f5c8a84f4588f887a90eb8645282031676e242/coverage-7.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0590e44dd2745c696a778f7bab6aa95256de2cbc8b8cff4f7db8ff09813d6969", size = 251165, upload-time = "2026-03-17T10:31:19.605Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/62/5502b73b97aa2e53ea22a39cf8649ff44827bef76d90bf638777daa27a9d/coverage-7.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d7cfad2d6d81dd298ab6b89fe72c3b7b05ec7544bdda3b707ddaecff8d25c161", size = 252908, upload-time = "2026-03-17T10:31:21.312Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/37/7792c2d69854397ca77a55c4646e5897c467928b0e27f2d235d83b5d08c6/coverage-7.13.5-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e092b9499de38ae0fbfbc603a74660eb6ff3e869e507b50d85a13b6db9863e15", size = 250873, upload-time = "2026-03-17T10:31:23.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/23/bc866fb6163be52a8a9e5d708ba0d3b1283c12158cefca0a8bbb6e247a43/coverage-7.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:48c39bc4a04d983a54a705a6389512883d4a3b9862991b3617d547940e9f52b1", size = 255030, upload-time = "2026-03-17T10:31:25.58Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8b/ef67e1c222ef49860701d346b8bbb70881bef283bd5f6cbba68a39a086c7/coverage-7.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2d3807015f138ffea1ed9afeeb8624fd781703f2858b62a8dd8da5a0994c57b6", size = 250694, upload-time = "2026-03-17T10:31:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/46/0d/866d1f74f0acddbb906db212e096dee77a8e2158ca5e6bb44729f9d93298/coverage-7.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ee2aa19e03161671ec964004fb74b2257805d9710bf14a5c704558b9d8dbaf17", size = 252469, upload-time = "2026-03-17T10:31:29.472Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9c/f9f5277b95184f764b24e7231e166dfdb5780a46d408a2ac665969416d61/coverage-7.13.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:972a9cd27894afe4bc2b1480107054e062df08e671df7c2f18c205e805ccd806", size = 261912, upload-time = "2026-03-17T10:31:41.324Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f6/7f1ab39393eeb50cfe4747ae8ef0e4fc564b989225aa1152e13a180d74f8/coverage-7.13.5-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4b59148601efcd2bac8c4dbf1f0ad6391693ccf7a74b8205781751637076aee3", size = 263987, upload-time = "2026-03-17T10:31:43.724Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d7/62c084fb489ed9c6fbdf57e006752e7c516ea46fd690e5ed8b8617c7d52e/coverage-7.13.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:505d7083c8b0c87a8fa8c07370c285847c1f77739b22e299ad75a6af6c32c5c9", size = 266416, upload-time = "2026-03-17T10:31:45.769Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f6/df63d8660e1a0bff6125947afda112a0502736f470d62ca68b288ea762d8/coverage-7.13.5-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:60365289c3741e4db327e7baff2a4aaacf22f788e80fa4683393891b70a89fbd", size = 267558, upload-time = "2026-03-17T10:31:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/02/353ca81d36779bd108f6d384425f7139ac3c58c750dcfaafe5d0bee6436b/coverage-7.13.5-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1b88c69c8ef5d4b6fe7dea66d6636056a0f6a7527c440e890cf9259011f5e606", size = 261163, upload-time = "2026-03-17T10:31:50.125Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/16/2e79106d5749bcaf3aee6d309123548e3276517cd7851faa8da213bc61bf/coverage-7.13.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5b13955d31d1633cf9376908089b7cebe7d15ddad7aeaabcbe969a595a97e95e", size = 263981, upload-time = "2026-03-17T10:31:51.961Z" },
+    { url = "https://files.pythonhosted.org/packages/29/c7/c29e0c59ffa6942030ae6f50b88ae49988e7e8da06de7ecdbf49c6d4feae/coverage-7.13.5-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:f70c9ab2595c56f81a89620e22899eea8b212a4041bd728ac6f4a28bf5d3ddd0", size = 261604, upload-time = "2026-03-17T10:31:53.872Z" },
+    { url = "https://files.pythonhosted.org/packages/40/48/097cdc3db342f34006a308ab41c3a7c11c3f0d84750d340f45d88a782e00/coverage-7.13.5-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:084b84a8c63e8d6fc7e3931b316a9bcafca1458d753c539db82d31ed20091a87", size = 265321, upload-time = "2026-03-17T10:31:55.997Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1f/4994af354689e14fd03a75f8ec85a9a68d94e0188bbdab3fc1516b55e512/coverage-7.13.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ad14385487393e386e2ea988b09d62dd42c397662ac2dabc3832d71253eee479", size = 260502, upload-time = "2026-03-17T10:31:58.308Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c6/9bb9ef55903e628033560885f5c31aa227e46878118b63ab15dc7ba87797/coverage-7.13.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7f2c47b36fe7709a6e83bfadf4eefb90bd25fbe4014d715224c4316f808e59a2", size = 262688, upload-time = "2026-03-17T10:32:00.141Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11' and sys_platform == 'linux'" },
+]
+
+[[package]]
 name = "cycler"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -320,6 +393,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/95/59/69ac07a49eeb587641f8a24eab5b5e406e308ed276e2a6de39d07a7cb6c3/datasets-2.14.7.tar.gz", hash = "sha256:394cf9b4ec0694b25945977b16ad5d18d5c15fb0e94141713eb8ead7452caf9e", size = 2181591, upload-time = "2023-11-15T08:12:38.218Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/23/80a2147a547cb2fd59eb92a13787c849b3efaefcea02a5c963dfc93f7c56/datasets-2.14.7-py3-none-any.whl", hash = "sha256:1a64041a7da4f4130f736fc371c1f528b8ddd208cebe156400f65719bdbba79d", size = 520442, upload-time = "2023-11-15T08:12:33.787Z" },
+]
+
+[[package]]
+name = "deepmerge"
+version = "2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/3a/b0ba594708f1ad0bc735884b3ad854d3ca3bdc1d741e56e40bbda6263499/deepmerge-2.0.tar.gz", hash = "sha256:5c3d86081fbebd04dd5de03626a0607b809a98fb6ccba5770b62466fe940ff20", size = 19890, upload-time = "2024-08-30T05:31:50.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/82/e5d2c1c67d19841e9edc74954c827444ae826978499bde3dfc1d007c8c11/deepmerge-2.0-py3-none-any.whl", hash = "sha256:6de9ce507115cff0bed95ff0ce9ecc31088ef50cbdf09bc90a09349a318b3d00", size = 13475, upload-time = "2024-08-30T05:31:48.659Z" },
 ]
 
 [[package]]
@@ -1398,6 +1480,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pymdown-extensions"
+version = "10.21.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown", marker = "sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1447,6 +1542,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/24/34/9f732b76456d64faffbef6232f1f9dbec7a7c4999ff46282fa418bd1af66/pytest_benchmark-5.2.3.tar.gz", hash = "sha256:deb7317998a23c650fd4ff76e1230066a76cb45dcece0aca5607143c619e7779", size = 341340, upload-time = "2025-11-09T18:48:43.215Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/29/e756e715a48959f1c0045342088d7ca9762a2f509b945f362a316e9412b7/pytest_benchmark-5.2.3-py3-none-any.whl", hash = "sha256:bc839726ad20e99aaa0d11a127445457b4219bdb9e80a1afc4b51da7f96b0803", size = 45255, upload-time = "2025-11-09T18:48:39.765Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"], marker = "sys_platform == 'linux'" },
+    { name = "pluggy", marker = "sys_platform == 'linux'" },
+    { name = "pytest", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]
@@ -1533,6 +1642,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
 ]
 
 [[package]]
@@ -1691,13 +1820,10 @@ name = "taac2026"
 source = { editable = "." }
 dependencies = [
     { name = "datasets", marker = "sys_platform == 'linux'" },
-    { name = "hypothesis", marker = "sys_platform == 'linux'" },
     { name = "matplotlib", marker = "sys_platform == 'linux'" },
     { name = "numpy", marker = "sys_platform == 'linux'" },
     { name = "orjson", marker = "sys_platform == 'linux'" },
     { name = "pyarrow", marker = "sys_platform == 'linux'" },
-    { name = "pytest", marker = "sys_platform == 'linux'" },
-    { name = "pytest-benchmark", marker = "sys_platform == 'linux'" },
     { name = "rich", marker = "sys_platform == 'linux'" },
     { name = "safetensors", marker = "sys_platform == 'linux'" },
     { name = "scikit-learn", marker = "sys_platform == 'linux'" },
@@ -1713,19 +1839,29 @@ cuda126 = [
     { name = "torch", marker = "sys_platform == 'linux'" },
     { name = "torchrec", marker = "sys_platform == 'linux'" },
 ]
+dev = [
+    { name = "hypothesis", marker = "sys_platform == 'linux'" },
+    { name = "pytest", marker = "sys_platform == 'linux'" },
+    { name = "pytest-benchmark", marker = "sys_platform == 'linux'" },
+    { name = "pytest-cov", marker = "sys_platform == 'linux'" },
+    { name = "ruff", marker = "sys_platform == 'linux'" },
+    { name = "zensical", marker = "sys_platform == 'linux'" },
+]
 
 [package.metadata]
 requires-dist = [
     { name = "datasets", specifier = "==2.14.7" },
     { name = "fbgemm-gpu", marker = "extra == 'cuda126'", specifier = "==1.2.0+cu126", index = "https://download.pytorch.org/whl/cu126", conflict = { package = "taac2026", extra = "cuda126" } },
-    { name = "hypothesis", specifier = "==6.151.12" },
+    { name = "hypothesis", marker = "extra == 'dev'", specifier = "==6.151.12" },
     { name = "matplotlib", specifier = "==3.10.8" },
     { name = "numpy", specifier = "==2.2.5" },
     { name = "orjson", specifier = "==3.11.8" },
     { name = "pyarrow", specifier = "==23.0.1" },
-    { name = "pytest", specifier = "==9.0.3" },
-    { name = "pytest-benchmark", specifier = "==5.2.3" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.3" },
+    { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = "==5.2.3" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==7.1.0" },
     { name = "rich", specifier = "==14.3.3" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.12" },
     { name = "safetensors", specifier = "==0.7.0" },
     { name = "scikit-learn", specifier = "==1.7.2" },
     { name = "tensorboard", specifier = "==2.19.0" },
@@ -1734,8 +1870,9 @@ requires-dist = [
     { name = "torchrec", marker = "extra == 'cuda126'", specifier = "==1.2.0+cu126", index = "https://download.pytorch.org/whl/cu126", conflict = { package = "taac2026", extra = "cuda126" } },
     { name = "tqdm", specifier = "==4.67.3" },
     { name = "triton", specifier = "==3.3.1" },
+    { name = "zensical", marker = "extra == 'dev'", specifier = "==0.0.38" },
 ]
-provides-extras = ["cuda126"]
+provides-extras = ["dev", "cuda126"]
 
 [[package]]
 name = "tensorboard"
@@ -2099,6 +2236,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/90/b2/f52381aac396d6778ce516b7bc149c79e65bfc068b5de2857ab69eeea3b7/yarl-1.23.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:a0e317df055958a0c1e79e5d2aa5a5eaa4a6d05a20d4b0c9c3f48918139c9fc6", size = 100295, upload-time = "2026-03-01T22:06:34.268Z" },
     { url = "https://files.pythonhosted.org/packages/e5/e8/638bae5bbf1113a659b2435d8895474598afe38b4a837103764f603aba56/yarl-1.23.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6f0fd84de0c957b2d280143522c4f91a73aada1923caee763e24a2b3fda9f8a5", size = 97784, upload-time = "2026-03-01T22:06:35.864Z" },
     { url = "https://files.pythonhosted.org/packages/69/68/c8739671f5699c7dc470580a4f821ef37c32c4cb0b047ce223a7f115757f/yarl-1.23.0-py3-none-any.whl", hash = "sha256:a2df6afe50dea8ae15fa34c9f824a3ee958d785fd5d089063d960bae1daa0a3f", size = 48288, upload-time = "2026-03-01T22:07:51.388Z" },
+]
+
+[[package]]
+name = "zensical"
+version = "0.0.38"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click", marker = "sys_platform == 'linux'" },
+    { name = "deepmerge", marker = "sys_platform == 'linux'" },
+    { name = "markdown", marker = "sys_platform == 'linux'" },
+    { name = "pygments", marker = "sys_platform == 'linux'" },
+    { name = "pymdown-extensions", marker = "sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "sys_platform == 'linux'" },
+    { name = "tomli", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/3d/96301349abd6e425b580f33474a51a5b6d68332ed538b8b6000497883794/zensical-0.0.38.tar.gz", hash = "sha256:e6fbf98dd851f5772d84648443e44fc8d8194ba0e09ec75c267fa033f6a0e43c", size = 3912956, upload-time = "2026-04-30T12:05:02.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/8b/6a47e5065bd9baf161785f1afd2c6e67dd3a7eafccb7ed06e0c7efd7b424/zensical-0.0.38-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8adc9e87d2d5921d9aa4204c4f7488b6349efd57916680d4905414e6461c942b", size = 12925558, upload-time = "2026-04-30T12:04:29.073Z" },
+    { url = "https://files.pythonhosted.org/packages/62/2a/62338132326dbc81bfd45d3ba47440dbd689be6c2cccf75f0005c6d0183d/zensical-0.0.38-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9576d21e3d5d6d6208df0873231838a3e42f05ba95316e4129df26a20edb8226", size = 12887161, upload-time = "2026-04-30T12:04:32.118Z" },
+    { url = "https://files.pythonhosted.org/packages/04/b3/f4f0af1eb6caf2d163fb9ba97da4592c74f26fe77309093bec35d8dbab5c/zensical-0.0.38-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d649045e59b6ecb0f543fddeed5b0dc4dab3fdeb0dae791d71b2be29335dd603", size = 13252488, upload-time = "2026-04-30T12:04:35.558Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e4/d5329e20c9417ca4789150cf78c994e2489c0c8fd92f10d93fe13c9d71da/zensical-0.0.38-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:196aa6ffaf2e80a173233e5e639227e59437a2dc31849051901a9456960f5f1a", size = 12955366, upload-time = "2026-04-30T12:04:39.159Z" },
+    { url = "https://files.pythonhosted.org/packages/38/26/11ca657164a2ca9347ffe665b57f5e788b628b6f21e7cf171cda7295a730/zensical-0.0.38-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3a0d173f4402a6201d990f05cb766aad872f222fffd9022d42421b331f69c60c", size = 13101610, upload-time = "2026-04-30T12:04:42.531Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/c7/0247c1efff36914b8a720dbe4accc5e1065d4ae986a81c71fb69cb1cc3e8/zensical-0.0.38-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c6056675c5f9e2e00afe6770232213e7dcf07e7e87a5e278d0dd7dbbd8b52316", size = 13159871, upload-time = "2026-04-30T12:04:46.169Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/ec/5ff0d64e58f2f498ba1696de3dccf147aec024f374ece4ae55f1313ad3c2/zensical-0.0.38-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:e447ca87827b7db7802a4b071247fb72968ab482f611eb8a951917f63b7784b2", size = 13311076, upload-time = "2026-04-30T12:04:49.826Z" },
+    { url = "https://files.pythonhosted.org/packages/78/80/8bd9054e15ac992c911a87a9d2651aa3468bc370ad97084f9902f2c9f7e0/zensical-0.0.38-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b913573ec99171534f51f0a5ab2032eee5416981ba2fe502601c5ac5a6da898", size = 13237935, upload-time = "2026-04-30T12:04:53.104Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- move pytest, hypothesis, benchmark, coverage, Ruff, and Zensical into a dedicated `dev` extra and update lockfile/docs accordingly
- keep packaged train/infer installs runtime-only by default, with optional `TAAC_BUNDLE_PIP_EXTRAS` for bundle-mode extras
- generate split-specific observed schema sidecars for PCVR train/eval flows and log dataset-role-specific schema payloads
- extend unit coverage for bundle install behavior, schema logging, row-group split reports, and evaluation/train observed schema outputs

## Validation
- `uv run pytest tests/unit/test_package_inference.py tests/unit/test_package_training.py tests/unit/test_pcvr_data_split.py tests/unit/test_pcvr_data_augmentation.py tests/unit/test_pcvr_infer_runtime.py -q`