### PR TITLE
Add vulture to dev CI

### DIFF
--- a/.agents/skills/taac-competition-environment/SKILL.md
+++ b/.agents/skills/taac-competition-environment/SKILL.md
@@ -71,7 +71,7 @@ uv run taac-package-infer --experiment experiments/interformer --output-dir /tmp
 Local defaults:
 
 - All local `run.sh` commands use CUDA profile `cuda126`; setting `TAAC_CUDA_PROFILE` or `--cuda-profile` to any other value is treated as an error.
-- Training, evaluation, inference, and local CLI tooling all reuse the same `cuda126` environment; pytest, coverage, Ruff, benchmark tooling, and Zensical live in the `dev` extra and should be installed with `uv sync --locked --extra dev --extra cuda126` when needed.
+- Training, evaluation, inference, and local CLI tooling all reuse the same `cuda126` environment; pytest, coverage, Ruff, Vulture, benchmark tooling, and Zensical live in the `dev` extra and should be installed with `uv sync --locked --extra dev --extra cuda126` when needed.
 - `TAAC_SKIP_UV_SYNC=1` skips automatic `uv sync` when the environment is already prepared.
 
 ## Dependency Profiles
@@ -80,7 +80,7 @@ The project requires Python `>=3.10,<3.14`.
 
 Important extras:
 
-- `dev`: Ruff, pytest, hypothesis, benchmark tooling, coverage helpers, and Zensical for local testing and docs work.
+- `dev`: Ruff, Vulture, pytest, hypothesis, benchmark tooling, coverage helpers, and Zensical for local testing and docs work.
 - `cuda126`: CUDA 12.6 PyTorch, FBGEMM, and TorchRec runtime for the repository.
 
 Do not point `uv` at an alternate package index unless you are intentionally updating dependency resolution. The lockfile is expected to resolve against the indexes declared in `pyproject.toml`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,15 @@ jobs:
       - name: 设置 uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
+      - name: 同步开发工具环境
+        run: uv sync --locked --extra dev
+
       - name: 运行 Ruff 风格检查
-        run: uv run --with ruff ruff check .
+        run: uv run ruff check .
+
+      - name: 运行 Vulture 死代码检查
+        if: matrix.python-version == env.CI_CANONICAL_PYTHON_VERSION
+        run: uv run vulture --config pyproject.toml
 
   test:
     name: CPU 单元测试 (Python ${{ matrix.python-version }})

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,7 +32,7 @@ uv sync --locked --extra dev --extra cuda126
 说明：
 
 - `cuda126` 是当前仓库唯一支持的本地 CUDA profile。
-- `dev` extra 包含 Ruff、Pytest、Coverage 和 Zensical。
+- `dev` extra 包含 Ruff、Vulture、Pytest、Coverage 和 Zensical。
 - 线上 Bundle 运行模式不依赖 `uv`；那部分见 [线上 Bundle 上传指南](guide/online-training-bundle.md)。
 
 ## 准备示例数据

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dev = [
 	"pytest-benchmark==5.2.3",
 	"pytest-cov==7.1.0",
 	"ruff==0.15.12",
+	"vulture==2.16",
 	"zensical==0.0.38",
 ]
 cuda126 = [
@@ -107,6 +108,10 @@ extend-select = ["B", "UP", "PTH", "RUF"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/gpu_env_support.py" = ["E402"]
+
+[tool.vulture]
+paths = ["src", "experiments", "tests"]
+min_confidence = 100
 
 [tool.coverage.run]
 branch = true

--- a/uv.lock
+++ b/uv.lock
@@ -1995,6 +1995,7 @@ dev = [
     { name = "pytest-benchmark", marker = "sys_platform == 'linux'" },
     { name = "pytest-cov", marker = "sys_platform == 'linux'" },
     { name = "ruff", marker = "sys_platform == 'linux'" },
+    { name = "vulture", marker = "sys_platform == 'linux'" },
     { name = "zensical", marker = "sys_platform == 'linux'" },
 ]
 
@@ -2022,6 +2023,7 @@ requires-dist = [
     { name = "torchrec", marker = "extra == 'cuda126'", specifier = "==1.2.0+cu126", index = "https://download.pytorch.org/whl/cu126", conflict = { package = "taac2026", extra = "cuda126" } },
     { name = "tqdm", specifier = "==4.67.3" },
     { name = "triton", specifier = "==3.3.1" },
+    { name = "vulture", marker = "extra == 'dev'", specifier = "==2.16" },
     { name = "zensical", marker = "extra == 'dev'", specifier = "==0.0.38" },
 ]
 provides-extras = ["dev", "cuda126"]
@@ -2294,6 +2296,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "vulture"
+version = "2.16"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tomli", marker = "python_full_version < '3.11' and sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/3e/4d08c5903b2c0c70cad583c170cc4a663fc6a61e2ad00b711fcda61358cd/vulture-2.16.tar.gz", hash = "sha256:f8d9f6e2af03011664a3c6c240c9765b3f392917d3135fddca6d6a68d359f717", size = 52680, upload-time = "2026-03-25T14:41:27.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/be/f935130312330614811dae2ea9df3f395f6d63889eb6c2e68c14507152ee/vulture-2.16-py3-none-any.whl", hash = "sha256:6e0f1c312cef1c87856957e5c2ca9608834a7c794c2180477f30bf0e4cc58eee", size = 26993, upload-time = "2026-03-25T14:41:26.21Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add pinned vulture to the dev extra and refresh the uv lockfile
- run Ruff and Vulture from the locked dev environment in CI
- document that dev extra now includes Vulture and configure Vulture to ignore compatibility-only need_weights parameters

Closes #86